### PR TITLE
Add support for Phyisical connection interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This are the commands to get started:
 ```bash
 git clone https://github.com/r00tat/smartmeter_homeassistant_burgenland.git smartmeter
 cd smartmeter
-cp config-template.yaml config.yaml
+cp smartmeter-config-template.yaml smartmeter-config.yaml
 # now edit the config
 sudo ln -s "$(pwd)/smartmeter.service" /etc/systemd/system/smartmeter.service && sudo systemctl enable smartmeter && sudo systemctl start smartmeter
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ git clone https://github.com/r00tat/smartmeter_homeassistant_burgenland.git smar
 cd smartmeter
 cp smartmeter-config-template.yaml smartmeter-config.yaml
 # now edit the config
+# if you are on debian make sure you got everything you need:
+curl -LsSf https://astral.sh/uv/install.sh | sh
 sudo ln -s "$(pwd)/smartmeter.service" /etc/systemd/system/smartmeter.service && sudo systemctl enable smartmeter && sudo systemctl start smartmeter
 ```
 
@@ -57,8 +59,8 @@ To follow the output of the program you can use `tail -f /var/log/daemon.log`.
 Initialize virtual environment:
 
 ```bash
-python3 -m venv .
-source bin/activate
+uv venv
+source .venv/bin/activate
 pip3 install -r requirements.txt
 ```
 

--- a/smartmeter/config.yaml
+++ b/smartmeter/config.yaml
@@ -20,6 +20,7 @@ boot: "auto"
 # privileged:
 #  - "NET_ADMIN"
 options:
+  interface_type: OPTICAL
   logging: INFO
   mqtt:
     device_id: "smartmeter"
@@ -38,6 +39,7 @@ options:
     stopbits: 1
     key: "" # hex key to decrypt message
 schema:
+  interface_type: list(OPTICAL|PHYSICAL)?
   logging: list(INFO|WARNING|ERROR|CRITICAL|DEBUG)?
   mqtt:
     device_id: "str?"

--- a/smartmeter/meter/bgld/data.py
+++ b/smartmeter/meter/bgld/data.py
@@ -1,6 +1,6 @@
-import json
+"""Data structure definition for burgenland smartmeter"""
 
-from gurux_dlms import GXReplyData
+import json
 
 
 class MeterData:
@@ -23,7 +23,7 @@ class MeterData:
     - Zähleridentifikationsnummern des Netzbetreibers
     """
 
-    def __init__(self, dlms_data: GXReplyData):
+    def __init__(self, dlms_data: list[any]):
         self.dlms_data = dlms_data
 
         self.voltage_l1 = 0
@@ -65,7 +65,7 @@ class MeterData:
             self.total_consumed,
             self.total_provided,
             *rest,
-        ) = self.dlms_data.value
+        ) = self.dlms_data
 
         if len(rest) >= 3:
             (self.x_1, self.x_2, self.x_3, *rest2) = rest

--- a/smartmeter/meter/dlms/.gitignore
+++ b/smartmeter/meter/dlms/.gitignore
@@ -1,0 +1,1 @@
+sample.xml

--- a/smartmeter/meter/dlms/read.py
+++ b/smartmeter/meter/dlms/read.py
@@ -75,7 +75,7 @@ def parse_xml(xml: str):
             parsed_value = int(child["Value"], 16)
 
         if child.name.startswith("OctetString"):
-            parsed_value = str(bytearray.fromhex(child["Value"]), encoding="utf-8")
+            parsed_value = bytearray.fromhex(child["Value"])
 
         if parsed_value is not None:
             all_values.append(parsed_value)

--- a/smartmeter/meter/dlms/read.py
+++ b/smartmeter/meter/dlms/read.py
@@ -1,5 +1,11 @@
 import logging
-from gurux_dlms import GXByteBuffer, GXReplyData, GXDLMSTranslator, TranslatorOutputType
+from gurux_dlms import (
+    GXByteBuffer,
+    GXReplyData,
+    GXDLMSTranslator,
+    TranslatorOutputType,
+    GXDLMSTranslatorMessage,
+)
 from gurux_dlms.enums import InterfaceType, Security
 from gurux_common import GXCommon
 from gurux_dlms.secure import GXDLMSSecureClient
@@ -28,6 +34,22 @@ def parse_dlms_data(data: bytes, key: str):
 
     # or plaintext?
     return notify
+
+
+def parse_pyhiscal_dlms_data(data: bytes, key: str):
+    """Parse DLMS data from an phyisical interface."""
+    tr = GXDLMSTranslator()
+    tr.blockCipherKey = GXByteBuffer(key)
+    tr.comments = True
+    msg = GXDLMSTranslatorMessage()
+    msg.message = GXByteBuffer(data)
+    xml = ""
+    pdu = GXByteBuffer()
+    tr.completePdu = True
+    while tr.findNextFrame(msg, pdu):
+        pdu.clear()
+        xml += tr.messageToXml(msg)
+    return xml
 
 
 def convert_to_xml(notify: GXReplyData):

--- a/smartmeter/meter/dlms/test_xml.py
+++ b/smartmeter/meter/dlms/test_xml.py
@@ -1,0 +1,46 @@
+"""Test XML parsing"""
+
+import logging
+from bs4 import BeautifulSoup
+
+
+log = logging.getLogger("meter.main")
+
+
+def parse_xml(xml: str):
+    """Parsing xml"""
+    soup = BeautifulSoup(xml, "xml")
+    struct = soup.find("Structure")
+
+    all_values = []
+
+    log.info("struct: %s", struct)
+    for child in struct.findChildren():
+        log.info("child: %s", child)
+        log.info("type: %s", child.name)
+        log.info("value: %s", child["Value"])
+        parsed_value = None
+        if child.name.startswith("UInt"):
+            parsed_value = int(child["Value"], 16)
+
+        if child.name.startswith("OctetString"):
+            parsed_value = str(bytearray.fromhex(child["Value"]), encoding="utf-8")
+
+        if parsed_value is not None:
+            all_values.append(parsed_value)
+
+    log.info("all values: %s", all_values)
+    return all_values
+
+
+def test():
+    """Test XML parsing."""
+    logging.basicConfig(level=logging.INFO)
+    log.info("reading xml")
+    with open("meter/dlms/sample.xml", encoding="utf-8") as f:
+        contents = f.read()
+
+    parse_xml(contents)
+
+
+test()

--- a/smartmeter/meter/serial/read.py
+++ b/smartmeter/meter/serial/read.py
@@ -5,7 +5,7 @@ from time import sleep
 from collections.abc import Callable
 import json
 
-from ..dlms.read import parse_dlms_data, parse_pyhiscal_dlms_data
+from ..dlms.read import parse_dlms_data, parse_pyhiscal_dlms_data, parse_xml
 from ..bgld.data import MeterData
 
 log = logging.getLogger("meter.serial.read")
@@ -99,6 +99,12 @@ class MeterReader:
             log.debug("received: %s", received_data)
             parsed_xml = parse_pyhiscal_dlms_data(received_data, self.key)
             log.info("XML Result for phyiscal interface:\n%s", parsed_xml)
+            values = parse_xml(parsed_xml)
+            if values and len(values) > 0:
+                data = MeterData(values)
+                log.debug("received meter data: %s", data)
+                if self.callback:
+                    self.callback(data)
 
     def start(self):
         """Start the read process"""

--- a/smartmeter/meter/serial/read.py
+++ b/smartmeter/meter/serial/read.py
@@ -92,7 +92,8 @@ class MeterReader:
     def phyiscal_loop(self):
         """Read data from the pyhsical serial port and parse it."""
         while self.should_run:
-            received_data = self.ser.read(111)
+            received_data = self.ser.read()
+            sleep(0.5)
             data_left = self.ser.inWaiting()  # check for remaining byte
             received_data += self.ser.read(data_left)
             log.debug("received: %s", received_data)

--- a/smartmeter/meter/serial/read.py
+++ b/smartmeter/meter/serial/read.py
@@ -5,7 +5,7 @@ from time import sleep
 from collections.abc import Callable
 import json
 
-from ..dlms.read import parse_dlms_data
+from ..dlms.read import parse_dlms_data, parse_pyhiscal_dlms_data
 from ..bgld.data import MeterData
 
 log = logging.getLogger("meter.serial.read")
@@ -28,6 +28,7 @@ class MeterReader:
         bytesize=serial.EIGHTBITS,
         parity=serial.PARITY_NONE,
         stopbits=serial.STOPBITS_ONE,
+        interface_type="OPTICAL",
         callback: Callable[[MeterData], None] = None,
     ):
         """Create a meter reader"""
@@ -48,6 +49,7 @@ class MeterReader:
             self.parity,
             self.stopbits,
         )
+        self.is_optical_inteface = interface_type == "OPTICAL"
 
         self.should_run = True
         self.is_running = False
@@ -59,7 +61,7 @@ class MeterReader:
             "connecting to serial port %s with %s%s%s",
             self.port,
             self.baudrate,
-            "N" if self.parity == serial.PARITY_NONE else "Y",
+            self.parity,
             self.stopbits,
         )
         self.ser = serial.Serial(
@@ -71,10 +73,8 @@ class MeterReader:
         if self.ser and not self.ser.closed:
             self.ser.close()
 
-    def start(self):
-        """Start the read process"""
-        self.is_running = True
-        self.connect()
+    def optical_loop(self):
+        """Read data from serial port and parse it."""
         while self.should_run:
             received_data = self.ser.read()  # read serial port
             sleep(0.5)
@@ -84,10 +84,30 @@ class MeterReader:
             decrypted_data = parse_dlms_data(received_data, self.key)
             log.debug("values: %s", decrypted_data.value)
             if decrypted_data.value:
-                data = MeterData(decrypted_data)
+                data = MeterData(decrypted_data.value)
                 log.debug("received meter data: %s", data)
                 if self.callback:
                     self.callback(data)
+
+    def phyiscal_loop(self):
+        """Read data from the pyhsical serial port and parse it."""
+        while self.should_run:
+            received_data = self.ser.read(111)
+            data_left = self.ser.inWaiting()  # check for remaining byte
+            received_data += self.ser.read(data_left)
+            log.debug("received: %s", received_data)
+            parsed_xml = parse_pyhiscal_dlms_data(received_data, self.key)
+            log.info("XML Result for phyiscal interface:\n%s", parsed_xml)
+
+    def start(self):
+        """Start the read process"""
+        self.is_running = True
+        self.connect()
+
+        if self.is_optical_inteface:
+            self.optical_loop()
+        else:
+            pass
 
         self.is_running = False
         self.disconnect()

--- a/smartmeter/meter/serial/read.py
+++ b/smartmeter/meter/serial/read.py
@@ -98,7 +98,7 @@ class MeterReader:
             received_data += self.ser.read(data_left)
             log.debug("received: %s", received_data)
             parsed_xml = parse_pyhiscal_dlms_data(received_data, self.key)
-            log.info("XML Result for phyiscal interface:\n%s", parsed_xml)
+            log.debug("XML Result:\n%s", parsed_xml)
             values = parse_xml(parsed_xml)
             if values and len(values) > 0:
                 data = MeterData(values)

--- a/smartmeter/meter/serial/read.py
+++ b/smartmeter/meter/serial/read.py
@@ -107,7 +107,7 @@ class MeterReader:
         if self.is_optical_inteface:
             self.optical_loop()
         else:
-            pass
+            self.phyiscal_loop()
 
         self.is_running = False
         self.disconnect()

--- a/smartmeter/meter/smartmeter.py
+++ b/smartmeter/meter/smartmeter.py
@@ -36,6 +36,7 @@ class SmartMqttMeter:
             bytesize=dlms_config.get("bytesize", serial.EIGHTBITS),
             stopbits=dlms_config.get("stopbits", serial.STOPBITS_ONE),
             parity=dlms_config.get("parity", serial.PARITY_NONE),
+            interface_type=self.config.get("interface_type", "OPTICAL"),
             callback=self.got_meter_data,
         )
         log.info("connecting to serial port")

--- a/smartmeter/requirements.txt
+++ b/smartmeter/requirements.txt
@@ -5,3 +5,5 @@ pyserial~=3.5
 PyYAML~=6.0
 ruff~=0.8.5
 setuptools
+lxml
+beautifulsoup4

--- a/smartmeter/smartmeter-config-template.yaml
+++ b/smartmeter/smartmeter-config-template.yaml
@@ -1,3 +1,6 @@
+logging: INFO
+interface_type: OPTICAL
+
 mqtt:
   # device_id: "smartmeter"
   # name: "Smart Meter"

--- a/smartmeter/smartmeter.service
+++ b/smartmeter/smartmeter.service
@@ -4,8 +4,8 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-WorkingDirectory=/home/pi/smartmeter/smartmeter
-ExecStart=/home/pi/smartmeter/smartmeter/smartmeter.sh
+WorkingDirectory=/home/pi/smartmeter_homeassistant_burgenland/smartmeter
+ExecStart=/home/pi/smartmeter_homeassistant_burgenland/smartmeter/smartmeter.sh
 Restart=always
 RestartSec=3
 User=pi

--- a/smartmeter/smartmeter.sh
+++ b/smartmeter/smartmeter.sh
@@ -5,11 +5,11 @@
 cd $(dirname "$0")
 
 # make sure we have a valid python venv
-if [[ ! -d bin || ! -d lib ]]; then
-  python3 -m venv .
-  source bin/activate
-  pip3 install -r requirements.txt
+if [[ ! -d .venv ]]; then
+  uv venv
+  source .venv/bin/activate
+  uv pip install -r requirements.txt
 fi
 
-source bin/activate
+source .venv/bin/activate
 python3 -m meter -c $PWD/smartmeter-config.yaml


### PR DESCRIPTION
Als option kann jetzt zwischen klassischen parser und neuem Parser unterschieden werden. Dies ist notwendig, da die HDLC Frames am physischen Interface nicht richtig gefunden werden. Der neue Parser funktioniert aber auch bei Optischen interfaces.


Hierbei bin ich auf einen Bug in der DLMS lib gestoßen: 
https://github.com/Gurux/Gurux.DLMS.Python/pull/44