### PR TITLE
Home Assistant device

### DIFF
--- a/smartmeter/config.yaml
+++ b/smartmeter/config.yaml
@@ -28,6 +28,7 @@ options:
     password: ""
     keepalive: 60
     prefix: ""
+    sensors_migrated: false
   dlms:
     port: "/dev/ttyUSB0"
     baudrate: 9600
@@ -48,6 +49,7 @@ schema:
     password: "str"
     keepalive: "int?"
     prefix: "str?"
+    sensors_migrated: bool?
   dlms:
     port: "str"
     baudrate: "int?"

--- a/smartmeter/meter/config.py
+++ b/smartmeter/meter/config.py
@@ -16,7 +16,12 @@ def get_config_file_contents():
         return f.read()
 
 
+def get_config() -> dict:
+    """Get the config from config.yaml."""
+    return yaml.safe_load(get_config_file_contents())
+
+
 def get_sw_version() -> str:
     """Get the current software version."""
-    config = yaml.load(get_config_file_contents())
+    config = get_config()
     return config.get("version", "")

--- a/smartmeter/meter/config.py
+++ b/smartmeter/meter/config.py
@@ -1,0 +1,22 @@
+"""Fetch addon config"""
+
+import os
+
+import yaml
+
+
+def get_config_file_name():
+    """Get the full path to the config.yaml file."""
+    return os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.yaml")
+
+
+def get_config_file_contents():
+    """Get the config from config.yaml."""
+    with open(get_config_file_name(), encoding="utf-8") as f:
+        return f.read()
+
+
+def get_sw_version() -> str:
+    """Get the current software version."""
+    config = yaml.load(get_config_file_contents())
+    return config.get("version", "")

--- a/smartmeter/meter/mqtt/client.py
+++ b/smartmeter/meter/mqtt/client.py
@@ -58,7 +58,7 @@ class MqttClient:
         # self.subscribe(self.topic_with_prefix("set"), self.set_display)
         # self.subscribe(self.topic_with_prefix("backlight/set"),
         #                self.display_backlight)
-        self.publish(self.topic_with_prefix("availability"), "online")
+        # self.publish(self.topic_with_prefix("availability"), "online")
 
         self.ha_discovery()
 

--- a/smartmeter/meter/mqtt/device.py
+++ b/smartmeter/meter/mqtt/device.py
@@ -25,6 +25,7 @@ class SmartMeterDevice(MqttClient):
                 "name": "Smart Meter",
                 "mf": "Landis+Gyr",
                 "mdl": "E450",
+                "sw": "1.0",
             },
         )
 
@@ -37,6 +38,7 @@ class SmartMeterDevice(MqttClient):
             components[device.get("unique_id")] = device | {
                 "~": self.base_topic,
                 "state_topic": "~/state",
+                "p": "sensor",
                 #  'retain': True,
                 "name": (
                     f"{self.config.get('name','Smart Meter')} " f"{device.get('name')}"

--- a/smartmeter/meter/mqtt/device.py
+++ b/smartmeter/meter/mqtt/device.py
@@ -21,7 +21,16 @@ class SmartMeterDevice(MqttClient):
         super().ha_discovery()
 
         log.info("publishing additional sensors")
+        components = {}
         for device in self.devices():
+            components[device.get("unique_id")] = device | {
+                "~": self.base_topic,
+                "state_topic": "~/state",
+                #  'retain': True,
+                "name": (
+                    f"{self.config.get('name','Smart Meter')} " f"{device.get('name')}"
+                ),
+            }
             self.publish(
                 (
                     f"homeassistant/sensor/f{self.device_id}"
@@ -37,9 +46,38 @@ class SmartMeterDevice(MqttClient):
                             f"{self.config.get('','Smart Meter')} "
                             f"{device.get('name')}"
                         ),
+                        "migrate_discovery": True,
+                        "device": {
+                            "ids": [self.device_id],
+                            "name": "Smart Meter",
+                        },
                     }
                 ),
             )
+
+        # log.info("publishing home assistant auto discovery")
+        # self.publish(
+        #     f"homeassistant/device/{self.device_id}/config",
+        #     json.dumps(
+        #         {
+        #             "dev": {
+        #                 "ids": self.device_id,
+        #                 "name": "Smart Meter",
+        #                 "mf": "Bla electronics",
+        #                 "mdl": "L+G450",
+        #                 "sw": "1.0",
+        #                 "sn": self.device_id,
+        #                 # "hw": "1.0rev2",
+        #             },
+        #             "o": {
+        #                 "name": "smartmeter_homeassistant_burgenland",
+        #                 "sw": "0.2.0",
+        #                 "url": "https://github.com/r00tat/smartmeter_homeassistant_burgenland",
+        #             },
+        #             "cmps": components,
+        #         }
+        #     ),
+        # )
 
     def devices(self):
         """List devices"""

--- a/smartmeter/meter/mqtt/device.py
+++ b/smartmeter/meter/mqtt/device.py
@@ -1,11 +1,9 @@
 import json
 import logging
-import os
 
 from ..bgld.data import MeterData
-from .client import MqttClient
 from ..config import get_sw_version
-
+from .client import MqttClient
 
 log = logging.getLogger("meter.mqtt.device")
 

--- a/smartmeter/meter/mqtt/device.py
+++ b/smartmeter/meter/mqtt/device.py
@@ -17,6 +17,17 @@ class SmartMeterDevice(MqttClient):
         """Publish the current status from meter data"""
         self.publish(self.topic_with_prefix("state"), data.to_json())
 
+    @property
+    def mqtt_device(self):
+        return (
+            {
+                "ids": [self.device_id],
+                "name": "Smart Meter",
+                "mf": "Landis+Gyr",
+                "mdl": "E450",
+            },
+        )
+
     def ha_discovery(self) -> None:
         super().ha_discovery()
 
@@ -47,37 +58,26 @@ class SmartMeterDevice(MqttClient):
                             f"{device.get('name')}"
                         ),
                         "migrate_discovery": True,
-                        "device": {
-                            "ids": [self.device_id],
-                            "name": "Smart Meter",
-                        },
+                        "device": self.mqtt_device,
                     }
                 ),
             )
 
-        # log.info("publishing home assistant auto discovery")
-        # self.publish(
-        #     f"homeassistant/device/{self.device_id}/config",
-        #     json.dumps(
-        #         {
-        #             "dev": {
-        #                 "ids": self.device_id,
-        #                 "name": "Smart Meter",
-        #                 "mf": "Bla electronics",
-        #                 "mdl": "L+G450",
-        #                 "sw": "1.0",
-        #                 "sn": self.device_id,
-        #                 # "hw": "1.0rev2",
-        #             },
-        #             "o": {
-        #                 "name": "smartmeter_homeassistant_burgenland",
-        #                 "sw": "0.2.0",
-        #                 "url": "https://github.com/r00tat/smartmeter_homeassistant_burgenland",
-        #             },
-        #             "cmps": components,
-        #         }
-        #     ),
-        # )
+        log.info("publishing home assistant auto discovery")
+        self.publish(
+            f"homeassistant/device/{self.device_id}/config",
+            json.dumps(
+                {
+                    "dev": self.mqtt_device,
+                    "o": {
+                        "name": "smartmeter_homeassistant_burgenland",
+                        "sw": "0.2.0",
+                        "url": "https://github.com/r00tat/smartmeter_homeassistant_burgenland",
+                    },
+                    "cmps": components,
+                }
+            ),
+        )
 
     def devices(self):
         """List devices"""


### PR DESCRIPTION
Mit diesem PR werden die Sensoren zu einem Device zusammen geführt.

Nach der Migration treten weiterhin Fehlermeldungen auf, da die Entitäten schon migriert sind. Nachdem das Rollout des Addons abgeschlossen ist, kann dies deaktiviert werden. 

Unter mqtt gibt es einen neuen config parameter sensors_migrated. Wenn das Addon einmal gestartet wurde, kann dieser Parameter auf true gesetzt werden.