### PR TITLE
Winkel Spannung zu Strom im home assistant verfügbar

### DIFF
--- a/smartmeter/meter/bgld/data.py
+++ b/smartmeter/meter/bgld/data.py
@@ -43,11 +43,11 @@ class MeterData:
         self.meter_id = None
 
         # Winkel Spannung L1 zu Strom L1
-        self.x_1 = 0
+        self.angle_1 = 0
         # Winkel Spannung L2 zu Strom L3
-        self.x_2 = 0
+        self.angle_2 = 0
         # Winkel Spannung L3 zu Strom L3
-        self.x_3 = 0
+        self.angle_3 = 0
 
         self.parse()
 
@@ -76,7 +76,7 @@ class MeterData:
         self.current_l3 = self.current_l3 / 100
 
         if len(rest) >= 3:
-            (self.x_1, self.x_2, self.x_3, *rest2) = rest
+            (self.angle_1, self.angle_2, self.angle_3, *rest2) = rest
         if len(rest) > 3:
             self.meter_id = str(rest[3], "UTF-8")
 
@@ -87,7 +87,7 @@ class MeterData:
             f"I({self.current_l1}A,{self.current_l2}A,{self.current_l3}A),"
             f"P({self.power_consumed}W,-{self.power_provided}W),"
             f"W({self.total_consumed}Wh,-{self.total_provided}Wh)"
-            # f"?({self.x_1},{self.x_2},{self.x_3})"
+            f"Angle({self.angle_1},{self.angle_2},{self.angle_3})"
             # f"id({self.meter_id})"
             f"]"
         )
@@ -106,6 +106,9 @@ class MeterData:
             "total_consumed": self.total_consumed,
             "total_provided": self.total_provided,
             "meter_id": self.meter_id,
+            "angle_l1": self.angle_1,
+            "angle_l2": self.angle_2,
+            "angle_l3": self.angle_3,
         }
 
     def to_json(self) -> str:

--- a/smartmeter/meter/mqtt/device.py
+++ b/smartmeter/meter/mqtt/device.py
@@ -49,7 +49,7 @@ class SmartMeterDevice(MqttClient):
                 "p": "sensor",
                 #  'retain': True,
                 "name": (
-                    f"{self.config.get('name','Smart Meter')} " f"{device.get('name')}"
+                    f"{self.config.get('name', 'Smart Meter')} {device.get('name')}"
                 ),
                 "device": self.mqtt_device,
             }
@@ -225,6 +225,27 @@ class SmartMeterDevice(MqttClient):
                 "value_template": "{{ value_json.current_l3 }}",
                 "unit_of_measurement": "A",
                 "device_class": "current",
+                "state_class": "measurement",
+            },
+            {
+                "name": "Angle between voltage L1 to current L1",
+                "unique_id": f"{self.device_id}_angle_l1",
+                "value_template": "{{ value_json.angle_l1 }}",
+                "unit_of_measurement": "°",
+                "state_class": "measurement",
+            },
+            {
+                "name": "Angle between voltage L2 to current L3",
+                "unique_id": f"{self.device_id}_angle_l2",
+                "value_template": "{{ value_json.angle_l2 }}",
+                "unit_of_measurement": "°",
+                "state_class": "measurement",
+            },
+            {
+                "name": "Angle between voltage L3 to current L3",
+                "unique_id": f"{self.device_id}_angle_l3",
+                "value_template": "{{ value_json.angle_l3 }}",
+                "unit_of_measurement": "°",
                 "state_class": "measurement",
             },
         ]


### PR DESCRIPTION
Die Werte der Winkel wurden bisher nicht gepublished. Mit dem PR werden diese Werte auch an Home Assistant übertragen:

    - Winkel Spannung L1 zu Strom L1
    - Winkel Spannung L2 zu Strom L3
    - Winkel Spannung L3 zu Strom L3
     
![image](https://github.com/user-attachments/assets/e66133a3-f0c0-4684-a0cc-333b5e57eaad)

Fixes #36