### PR TITLE
ci: migrate from deprecated home-assistant/builder to reusable actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Lint and Test"
     runs-on: "ubuntu-latest"
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: "Checkout the repository"
         uses: "actions/checkout@v6.0.2"
@@ -47,17 +47,35 @@ jobs:
           cd smartmeter &&
           python3 -m pytest tests/ -v
 
-      # - name: "Adjust version number"
-      #   shell: "bash"
-      #   run: |
-      #     yq -i -o json '.version="${{ github.event.release.tag_name }}"' \
-      #       "${{ github.workspace }}/custom_components/blaulichtsms/manifest.json"
 
-      - name: Test build
-        uses: home-assistant/builder@master
+  test-build:
+    name: "Test build ${{ matrix.arch }} image"
+    needs: pull_request
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            os: ubuntu-24.04
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
+
+      - name: "Test build ${{ matrix.arch }} image"
+        uses: home-assistant/builder/actions/build-image@2026.03.2
         with:
-          args: |
-            --test \
-            --amd64 --aarch64 \
-            --target smartmeter \
-            --docker-hub paulwoelfel
+          arch: ${{ matrix.arch }}
+          context: smartmeter
+          image: docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_${{ matrix.arch }}
+          image-tags: test
+          version: test
+          container-registry-password: "unused"
+          build-args: |
+            BUILD_FROM=ghcr.io/hassio-addons/base-python:stable
+          push: "false"
+          cosign: "false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
 permissions: {}
 
 jobs:
-  release:
-    name: "Release"
+  prepare:
+    name: "Prepare release"
     runs-on: "ubuntu-latest"
     permissions:
       contents: write
@@ -19,8 +19,10 @@ jobs:
 
       - name: "Adjust version number"
         shell: "bash"
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          yq -i '.version="${{ github.event.release.tag_name }}"' \
+          yq -i '.version=strenv(RELEASE_TAG)' \
             "${{ github.workspace }}/smartmeter/config.yaml"
 
       - name: "✏️ Generate release changelog"
@@ -47,15 +49,40 @@ jobs:
           commit_message: "Update version to ${{ github.event.release.tag_name }} and update CHANGELOG.md"
           file_pattern: smartmeter/config.yaml smartmeter/CHANGELOG.md
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
+  build:
+    name: "Build ${{ matrix.arch }} image"
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            os: ubuntu-24.04
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Publish
-        uses: home-assistant/builder@master
+          ref: main
+
+      - name: "Build and publish ${{ matrix.arch }} image"
+        uses: home-assistant/builder/actions/build-image@2026.03.2
         with:
-          args: |
-            --amd64 --aarch64 \
-            --target smartmeter \
-            --docker-hub paulwoelfel
+          arch: ${{ matrix.arch }}
+          context: smartmeter
+          image: docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_${{ matrix.arch }}
+          image-tags: |
+            ${{ github.event.release.tag_name }}
+            latest
+          version: ${{ github.event.release.tag_name }}
+          container-registry: docker.io
+          container-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          container-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          build-args: |
+            BUILD_FROM=ghcr.io/hassio-addons/base-python:stable
+          push: "true"
+          cosign: "false"


### PR DESCRIPTION
## Summary
- Replace deprecated `home-assistant/builder@master` with the new reusable `home-assistant/builder/actions/build-image@2026.03.2` action.
- Split the release workflow into a `prepare` job (version bump + changelog commit) and a matrix `build` job that runs natively on `amd64` (ubuntu-24.04) and `aarch64` (ubuntu-24.04-arm) runners, pushing each per-arch image to Docker Hub.
- Pull request workflow now runs per-arch test builds with `push: "false"` instead of the old `--test` mode.
- Harden the release `yq` step by passing the tag via env + `strenv()` rather than inline expression interpolation.

## Notes
- No multi-arch manifest is needed — Home Assistant supervisor resolves `{arch}` in `smartmeter/config.yaml` to the matching per-arch image.
- `cosign: "false"` since we publish to Docker Hub.
- Verify that `ubuntu-24.04-arm` runners are available to this repo.

## Test plan
- [ ] Open this PR and confirm the `test-build` matrix jobs build successfully for `amd64` and `aarch64`.
- [ ] On next release, verify the `prepare` job commits the version/changelog to `main` and both build jobs push `paulwoelfel/smartmeter_homeassistant_burgenland_{amd64,aarch64}` tags to Docker Hub.