### PR TITLE
fix(mqtt): make TLS opt-in via explicit `tls` flag + config JSON schema (#94)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,8 @@
   "editor.rulers": [80],
   "yaml.schemas": {
     "./smartmeter/config.schema.json": [
-      "smartmeter/smartmeter-config-template.yaml",
+      "smartmeter/smartmeter-config.example.yaml",
       "smartmeter/smartmeter-config.yaml"
     ]
-  },
-  "yaml.schemaStore.enable": false
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "editor.rulers": [80]
+  "editor.rulers": [80],
+  "yaml.schemas": {
+    "./smartmeter/config.schema.json": [
+      "smartmeter/smartmeter-config-template.yaml",
+      "smartmeter/smartmeter-config.yaml"
+    ]
+  },
+  "yaml.schemaStore.enable": false
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This are the commands to get started:
 ```bash
 git clone https://github.com/r00tat/smartmeter_homeassistant_burgenland.git smartmeter
 cd smartmeter
-cp smartmeter-config-template.yaml smartmeter-config.yaml
+cp smartmeter-config.example.yaml smartmeter-config.yaml
 # now edit the config
 # if you are on debian make sure you got everything you need:
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/docs/plans/2026-05-31-mqtt-tls-config-design.md
+++ b/docs/plans/2026-05-31-mqtt-tls-config-design.md
@@ -79,7 +79,20 @@ this is called out in DOCS.md and the changelog.
 4. **`smartmeter/CHANGELOG.md`** — add an entry under `[Unreleased]`
    documenting the bugfix and the new `tls` option.
 
-5. **`smartmeter/tests/`** — new unit tests for `_configure_tls`
+5. **`smartmeter/config.schema.json`** (new) — a JSON Schema (Draft 2020-12)
+   describing the runtime config structure (`logging`, `meter_type`,
+   `interface_type`, `mqtt`, `dlms`), including the new `mqtt.tls`
+   boolean. It mirrors the rules already enforced in
+   `config_validation.py` (required `mqtt.host`, `dlms.key` 32-hex, parity
+   enum, meter_type enum) so editors and CI can validate config files.
+   `smartmeter-config-template.yaml` gets a
+   `# yaml-language-server: $schema=./config.schema.json` header so editors
+   pick up the schema automatically. The schema documents the **runtime**
+   config consumed by `python -m meter -c <file>` (and the add-on's
+   `/data/options.json`), not the Home Assistant add-on manifest, which
+   keeps its own `schema:` block in `config.yaml`.
+
+6. **`smartmeter/tests/`** — new unit tests for `_configure_tls`
    (mocking `mqtt.Client`):
    - `tls` missing → `tls_set` **not** called (regression test for #94).
    - `tls: false` with certs present → `tls_set` **not** called.

--- a/docs/plans/2026-05-31-mqtt-tls-config-design.md
+++ b/docs/plans/2026-05-31-mqtt-tls-config-design.md
@@ -1,0 +1,103 @@
+# Design: Explicit MQTT TLS Configuration
+
+- **Issue:** [#94](https://github.com/r00tat/smartmeter_homeassistant_burgenland/issues/94)
+- **Date:** 2026-05-31
+- **Status:** Accepted – implementation pending
+
+## Goal
+
+Make MQTT TLS an explicit, opt-in feature controlled by a single boolean
+switch, and fix the bug where TLS is enabled even when the user did not
+ask for it. Trusted CA / client certificates remain configurable.
+
+## Problem
+
+`MqttClient._configure_tls()` currently enables TLS when *any* `tls_*`
+value is "non-empty":
+
+```python
+if not any(
+    value not in (None, "")
+    for value in (tls_ca, tls_cert, tls_key, tls_insecure)
+):
+    return
+```
+
+The add-on default config ships `tls_insecure: false`. Because
+`False not in (None, "")` evaluates to `True`, the `any(...)` is always
+truthy, so TLS is **always** enabled — even with empty certificate fields
+and the standard non-TLS port `1883`. paho then attempts a TLS handshake
+against a plain broker and fails:
+
+```
+INFO  enabling MQTT TLS
+ERROR [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol
+```
+
+This is exactly the failure reported in #94.
+
+## Decision
+
+- Introduce an explicit boolean option `mqtt.tls` (default `false`).
+- TLS is enabled **only** when `tls: true`. There is **no** fallback that
+  infers TLS from the presence of certificate fields.
+- When `tls: true`, the existing flat `tls_*` keys are evaluated:
+  - `tls_ca` — trusted CA / server certificate (PEM). If omitted, paho
+    falls back to the system CA store (works with publicly trusted brokers).
+  - `tls_cert` + `tls_key` — optional client certificate for mutual TLS.
+  - `tls_insecure` — disable hostname/certificate verification (testing only).
+- The default MQTT port stays `1883` (standard, non-TLS). The port is
+  never changed automatically; TLS brokers commonly listen on a separate
+  port (often `8883`) which the user must set manually.
+
+Rationale for the strict (no-fallback) behaviour: it is maximally
+predictable and cleanly fixes #94. The feature shipped in 0.6.0 and the
+old auto-enable was buggy, so there is no well-behaved legacy config to
+preserve. Existing users with certificates set must add `tls: true` once;
+this is called out in DOCS.md and the changelog.
+
+## Affected Components
+
+1. **`smartmeter/meter/mqtt/client.py`** — `_configure_tls()`:
+   replace the `any(...)` block with an early return guarded on the new
+   switch:
+   ```python
+   if not self.config.get("tls"):
+       return
+   ```
+   The remainder (`tls_set(...)`, `tls_insecure_set(...)`) is unchanged and
+   keeps reading the flat `tls_*` keys.
+
+2. **`smartmeter/config.yaml`** — add `tls: false` to `options.mqtt`
+   (before the `tls_ca` field) and `tls: bool?` to `schema.mqtt`.
+
+3. **`smartmeter/DOCS.md`** — rewrite the "Optional MQTT TLS" section: TLS
+   is enabled via `tls: true`; the `tls_*` fields only take effect then;
+   note the separate-port convention (e.g. `8883`) while keeping `1883`
+   as the documented default.
+
+4. **`smartmeter/CHANGELOG.md`** — add an entry under `[Unreleased]`
+   documenting the bugfix and the new `tls` option.
+
+5. **`smartmeter/tests/`** — new unit tests for `_configure_tls`
+   (mocking `mqtt.Client`):
+   - `tls` missing → `tls_set` **not** called (regression test for #94).
+   - `tls: false` with certs present → `tls_set` **not** called.
+   - `tls: true`, no certs → `tls_set()` called with `ca_certs=None`.
+   - `tls: true` with `tls_ca` and `tls_insecure: true` → `tls_set` and
+     `tls_insecure_set(True)` called with the expected arguments.
+
+## Out of Scope (YAGNI)
+
+- Automatic switching of the port to `8883` when TLS is enabled.
+- A nested `tls:` configuration block (would break the existing flat
+  `tls_*` keys for no functional gain).
+- Backward-compat fallback that infers TLS from certificate presence.
+
+## Test / Verification
+
+- `pytest` (new TLS tests pass, existing suite green).
+- `ruff` clean.
+- Manual: `tls: false` (or unset) connects to a plain broker on `1883`
+  without attempting a handshake; `tls: true` against a TLS broker
+  performs the handshake.

--- a/docs/plans/2026-05-31-mqtt-tls-config-plan.md
+++ b/docs/plans/2026-05-31-mqtt-tls-config-plan.md
@@ -1,0 +1,267 @@
+# MQTT TLS Explicit-Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MQTT TLS opt-in via an explicit `mqtt.tls` boolean and stop TLS from being force-enabled by the `tls_insecure: false` default (bug #94).
+
+**Architecture:** Gate `MqttClient._configure_tls()` on a single boolean config key (`tls`). When false/absent, return immediately and never touch paho's `tls_set`. When true, evaluate the existing flat `tls_*` keys exactly as today. Add the option to the add-on schema, document it, and lock the behaviour with unit tests.
+
+**Tech Stack:** Python 3.14, paho-mqtt, pytest, ruff. Tests run from the `smartmeter/` directory: `python -m pytest tests/`.
+
+---
+
+## File Structure
+
+- `smartmeter/meter/mqtt/client.py` — `_configure_tls()` gate logic (the fix).
+- `smartmeter/config.yaml` — add-on `options.mqtt.tls` default + `schema.mqtt.tls` type.
+- `smartmeter/tests/test_mqtt_tls.py` — **new** unit tests for the gate.
+- `smartmeter/DOCS.md` — "Optional MQTT TLS" section rewrite.
+- `smartmeter/CHANGELOG.md` — `[Unreleased]` entry.
+
+---
+
+## Task 1: Fix and lock `_configure_tls` behaviour (TDD)
+
+**Files:**
+- Test: `smartmeter/tests/test_mqtt_tls.py` (create)
+- Modify: `smartmeter/meter/mqtt/client.py:46-66`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `smartmeter/tests/test_mqtt_tls.py` with:
+
+```python
+"""Tests for MqttClient._configure_tls TLS gating (issue #94)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from meter.mqtt.client import MqttClient
+
+
+def _make_client(mqtt_cfg: dict) -> MagicMock:
+    """Instantiate MqttClient with paho Client patched; return the mock client."""
+    cfg = {"host": "mqtt.local", **mqtt_cfg}
+    with patch("meter.mqtt.client.mqtt.Client") as client_cls:
+        client_instance = MagicMock()
+        client_cls.return_value = client_instance
+        MqttClient(cfg)
+    return client_instance
+
+
+def test_tls_not_enabled_when_key_absent() -> None:
+    # Regression for #94: default config has no `tls` key.
+    client = _make_client({})
+    client.tls_set.assert_not_called()
+
+
+def test_tls_not_enabled_when_false_with_insecure_false() -> None:
+    # The exact #94 trigger: tls_insecure default False must not enable TLS.
+    client = _make_client({"tls": False, "tls_insecure": False})
+    client.tls_set.assert_not_called()
+
+
+def test_tls_not_enabled_when_certs_present_but_tls_false() -> None:
+    # No fallback: certs alone do not enable TLS.
+    client = _make_client({"tls": False, "tls_ca": "/config/ca.pem"})
+    client.tls_set.assert_not_called()
+
+
+def test_tls_enabled_without_certs_uses_system_ca() -> None:
+    client = _make_client({"tls": True})
+    client.tls_set.assert_called_once_with(
+        ca_certs=None, certfile=None, keyfile=None
+    )
+
+
+def test_tls_enabled_with_ca_and_insecure() -> None:
+    client = _make_client(
+        {
+            "tls": True,
+            "tls_ca": "/config/ca.pem",
+            "tls_cert": "/config/client.pem",
+            "tls_key": "/config/client.key",
+            "tls_insecure": True,
+        }
+    )
+    client.tls_set.assert_called_once_with(
+        ca_certs="/config/ca.pem",
+        certfile="/config/client.pem",
+        keyfile="/config/client.key",
+    )
+    client.tls_insecure_set.assert_called_once_with(True)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `smartmeter/`): `python -m pytest tests/test_mqtt_tls.py -v`
+Expected: `test_tls_not_enabled_when_key_absent`, `test_tls_not_enabled_when_false_with_insecure_false`, and `test_tls_not_enabled_when_certs_present_but_tls_false` FAIL (current code calls `tls_set` because `tls_insecure: False` / certs trigger the buggy `any(...)`). The two `tls: True` tests should pass already.
+
+- [ ] **Step 3: Apply the minimal fix**
+
+In `smartmeter/meter/mqtt/client.py`, replace the body of `_configure_tls` (lines 46-66) with:
+
+```python
+    def _configure_tls(self) -> None:
+        """Enable TLS only when explicitly switched on via ``tls: true``."""
+        if not self.config.get("tls"):
+            return
+
+        tls_ca = self.config.get("tls_ca")
+        tls_cert = self.config.get("tls_cert")
+        tls_key = self.config.get("tls_key")
+        tls_insecure = self.config.get("tls_insecure")
+
+        log.info("enabling MQTT TLS")
+        self.client.tls_set(
+            ca_certs=tls_ca or None,
+            certfile=tls_cert or None,
+            keyfile=tls_key or None,
+        )
+        if tls_insecure is not None:
+            self.client.tls_insecure_set(bool(tls_insecure))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `smartmeter/`): `python -m pytest tests/test_mqtt_tls.py -v`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Run the full suite + ruff**
+
+Run (from `smartmeter/`): `python -m pytest tests/ -q && ruff check meter tests`
+Expected: all tests pass, ruff reports no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add smartmeter/meter/mqtt/client.py smartmeter/tests/test_mqtt_tls.py
+git commit -m "fix(mqtt): only enable TLS when tls: true (#94)"
+```
+
+---
+
+## Task 2: Add `tls` to the add-on config schema
+
+**Files:**
+- Modify: `smartmeter/config.yaml:34` (options) and `:61` (schema)
+
+- [ ] **Step 1: Add the option default**
+
+In `smartmeter/config.yaml`, under `options.mqtt`, add `tls: false` immediately **before** the `tls_ca: ""` line so the block reads:
+
+```yaml
+    sensors_migrated: false
+    publish_interval: 30
+    tls: false
+    tls_ca: ""
+    tls_cert: ""
+    tls_key: ""
+    tls_insecure: false
+```
+
+- [ ] **Step 2: Add the schema type**
+
+In `smartmeter/config.yaml`, under `schema.mqtt`, add `tls: bool?` immediately **before** the `tls_ca: "str?"` line so the block reads:
+
+```yaml
+    sensors_migrated: bool?
+    publish_interval: int?
+    tls: bool?
+    tls_ca: "str?"
+    tls_cert: "str?"
+    tls_key: "str?"
+    tls_insecure: bool?
+```
+
+- [ ] **Step 3: Verify the YAML still parses**
+
+Run (from repo root): `python -c "import yaml; yaml.safe_load(open('smartmeter/config.yaml'))" && echo OK`
+Expected: prints `OK` with no traceback.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add smartmeter/config.yaml
+git commit -m "feat(mqtt): add explicit tls option to add-on schema (#94)"
+```
+
+---
+
+## Task 3: Update DOCS.md and CHANGELOG.md
+
+**Files:**
+- Modify: `smartmeter/DOCS.md` ("Optional MQTT TLS" section, ~line 35-37)
+- Modify: `smartmeter/CHANGELOG.md` (`[Unreleased]` section near the top)
+
+- [ ] **Step 1: Rewrite the DOCS.md TLS section**
+
+Replace the existing "## Optional MQTT TLS" section body in `smartmeter/DOCS.md` with:
+
+```markdown
+## Optional MQTT TLS
+
+TLS is disabled by default. To connect to an MQTT broker over TLS, set
+`tls: true` under `mqtt`. The default port stays `1883`; TLS brokers
+usually listen on a separate port (commonly `8883`), so set `port`
+accordingly.
+
+When `tls: true`, the following options take effect (they are ignored
+while `tls` is `false`):
+
+- `tls_ca`: path to a CA certificate (PEM) the broker is trusted against.
+  If left empty, the system CA store is used (works with publicly trusted
+  brokers).
+- `tls_cert` and `tls_key`: enable mutual TLS with a client certificate
+  and key.
+- `tls_insecure: true`: skip hostname/certificate verification (testing
+  only).
+
+Certificate paths must be readable from within the add-on container (e.g.
+mounted via `share:ro` or `config:ro`).
+```
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+In `smartmeter/CHANGELOG.md`, under the `## [Unreleased]` heading, add a `**Fixed bugs:**` block (or extend it if present) and an enhancement note:
+
+```markdown
+**Fixed bugs:**
+
+- MQTT no longer attempts a TLS handshake on the plain `1883` port. TLS
+  was previously force-enabled by the `tls_insecure: false` default,
+  causing `[SSL: UNEXPECTED_EOF_WHILE_READING]` connection failures
+  ([\#94](https://github.com/r00tat/smartmeter_homeassistant_burgenland/issues/94)).
+
+**Implemented enhancements:**
+
+- Add explicit `mqtt.tls` option. TLS is now opt-in via `tls: true`; the
+  `tls_ca` / `tls_cert` / `tls_key` / `tls_insecure` options only apply
+  when TLS is enabled.
+```
+
+(If `## [Unreleased]` already contains an `**Implemented enhancements:**`
+block for the Netz NÖ feature, add the new bullet to it rather than
+duplicating the heading, and add the `**Fixed bugs:**` block above it.)
+
+- [ ] **Step 3: Verify markdown is well-formed**
+
+Run (from repo root): `grep -n "tls" smartmeter/DOCS.md && grep -n "#94\|tls" smartmeter/CHANGELOG.md`
+Expected: the new TLS lines appear in both files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add smartmeter/DOCS.md smartmeter/CHANGELOG.md
+git commit -m "docs: document explicit MQTT tls option (#94)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 = client gate fix + regression tests; Task 2 = schema option; Task 3 = DOCS + CHANGELOG. All design "Affected Components" covered.
+- **No fallback:** `test_tls_not_enabled_when_certs_present_but_tls_false` locks the strict no-fallback decision.
+- **Type consistency:** the config key is `tls` (boolean) everywhere — config.yaml options, schema, `self.config.get("tls")`, and all tests.
+- **Port unchanged:** no task modifies the default `1883`; docs only mention `8883` as a manual choice.

--- a/docs/plans/2026-05-31-mqtt-tls-config-plan.md
+++ b/docs/plans/2026-05-31-mqtt-tls-config-plan.md
@@ -17,6 +17,8 @@
 - `smartmeter/tests/test_mqtt_tls.py` — **new** unit tests for the gate.
 - `smartmeter/DOCS.md` — "Optional MQTT TLS" section rewrite.
 - `smartmeter/CHANGELOG.md` — `[Unreleased]` entry.
+- `smartmeter/config.schema.json` — **new** JSON Schema (Draft 2020-12) for the runtime config, including `mqtt.tls`.
+- `smartmeter/smartmeter-config-template.yaml` — add `# yaml-language-server: $schema=./config.schema.json` header.
 
 ---
 
@@ -259,9 +261,192 @@ git commit -m "docs: document explicit MQTT tls option (#94)"
 
 ---
 
+## Task 4: Add JSON Schema for the runtime config + editor header
+
+**Files:**
+- Create: `smartmeter/config.schema.json`
+- Modify: `smartmeter/smartmeter-config-template.yaml:1` (add schema header)
+- Test: `smartmeter/tests/test_config_schema.py` (create)
+
+- [ ] **Step 0: Add the `jsonschema` dev dependency**
+
+`jsonschema` is not currently installed. Add this line to
+`smartmeter/requirements-dev.txt`:
+
+```text
+jsonschema~=4.0
+```
+
+Then install (from `smartmeter/`): `pip install -r requirements-dev.txt`
+Expected: `jsonschema` installs without error.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `smartmeter/tests/test_config_schema.py`. It validates the bundled
+template against the schema and checks the `tls` option is present and
+boolean.
+
+```python
+"""The runtime config schema accepts the template and the mqtt.tls option."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import yaml
+from jsonschema import Draft202012Validator
+
+_HERE = os.path.dirname(os.path.dirname(__file__))  # smartmeter/
+_SCHEMA = os.path.join(_HERE, "config.schema.json")
+_TEMPLATE = os.path.join(_HERE, "smartmeter-config-template.yaml")
+
+
+def _schema() -> dict:
+    with open(_SCHEMA, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_schema_is_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(_schema())
+
+
+def test_template_matches_schema() -> None:
+    with open(_TEMPLATE, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    # template ships an empty host/key (user fills them); validate shape only
+    data.setdefault("mqtt", {})["host"] = "mqtt.local"
+    data.setdefault("dlms", {})["key"] = "00" * 16
+    Draft202012Validator(_schema()).validate(data)
+
+
+def test_schema_allows_tls_boolean() -> None:
+    schema = _schema()
+    mqtt_props = schema["properties"]["mqtt"]["properties"]
+    assert mqtt_props["tls"]["type"] == "boolean"
+
+
+def test_schema_rejects_unknown_meter_type() -> None:
+    cfg = {
+        "meter_type": "bogus",
+        "mqtt": {"host": "h"},
+        "dlms": {"key": "00" * 16, "port": "/dev/ttyUSB0"},
+    }
+    errors = list(Draft202012Validator(_schema()).iter_errors(cfg))
+    assert errors, "unknown meter_type should fail validation"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `smartmeter/`): `python -m pytest tests/test_config_schema.py -v`
+Expected: FAIL — `config.schema.json` does not exist yet (FileNotFoundError).
+
+- [ ] **Step 3: Create the schema file**
+
+Create `smartmeter/config.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/r00tat/smartmeter_homeassistant_burgenland/config.schema.json",
+  "title": "Smartmeter add-on runtime configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "logging": {
+      "type": "string",
+      "enum": ["INFO", "WARNING", "ERROR", "CRITICAL", "DEBUG"]
+    },
+    "meter_type": {
+      "type": "string",
+      "enum": ["burgenland", "noe_evn"],
+      "default": "burgenland"
+    },
+    "interface_type": {
+      "type": "string",
+      "enum": ["OPTICAL", "PHYSICAL"]
+    },
+    "mqtt": {
+      "type": "object",
+      "required": ["host"],
+      "additionalProperties": false,
+      "properties": {
+        "device_id": {"type": "string"},
+        "name": {"type": "string"},
+        "host": {"type": "string", "minLength": 1},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "user": {"type": "string"},
+        "password": {"type": "string"},
+        "keepalive": {"type": "integer", "minimum": 1},
+        "prefix": {"type": "string"},
+        "sensors_migrated": {"type": "boolean"},
+        "publish_interval": {"type": "integer", "minimum": 1},
+        "tls": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable MQTT over TLS. The tls_* options apply only when true."
+        },
+        "tls_ca": {"type": "string"},
+        "tls_cert": {"type": "string"},
+        "tls_key": {"type": "string"},
+        "tls_insecure": {"type": "boolean"}
+      }
+    },
+    "dlms": {
+      "type": "object",
+      "required": ["key", "port"],
+      "additionalProperties": false,
+      "properties": {
+        "port": {"type": "string", "minLength": 1},
+        "baudrate": {"type": "integer"},
+        "bytesize": {"type": "integer"},
+        "parity": {
+          "type": "string",
+          "enum": ["NONE", "EVEN", "ODD", "MARK", "SPACE"]
+        },
+        "stopbits": {"type": "integer"},
+        "key": {"type": "string", "pattern": "^[0-9a-fA-F]{32}$"},
+        "hdlc_frame_size": {"type": "integer"}
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Add the schema header to the template**
+
+Add as the **first line** of `smartmeter/smartmeter-config-template.yaml`:
+
+```yaml
+# yaml-language-server: $schema=./config.schema.json
+```
+
+(Keep the existing `logging: INFO` line as line 2.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run (from `smartmeter/`): `python -m pytest tests/test_config_schema.py -v`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 6: Run the full suite + ruff + JSON sanity**
+
+Run (from `smartmeter/`):
+`python -m pytest tests/ -q && ruff check meter tests && python -c "import json; json.load(open('config.schema.json'))" && echo OK`
+Expected: tests pass, ruff clean, prints `OK`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add smartmeter/config.schema.json smartmeter/smartmeter-config-template.yaml smartmeter/tests/test_config_schema.py smartmeter/requirements-dev.txt
+git commit -m "feat: add JSON schema for runtime config validation (#94)"
+```
+
+---
+
 ## Self-Review Notes
 
-- **Spec coverage:** Task 1 = client gate fix + regression tests; Task 2 = schema option; Task 3 = DOCS + CHANGELOG. All design "Affected Components" covered.
+- **Spec coverage:** Task 1 = client gate fix + regression tests; Task 2 = add-on schema option; Task 3 = DOCS + CHANGELOG; Task 4 = JSON Schema + template header. All design "Affected Components" covered.
 - **No fallback:** `test_tls_not_enabled_when_certs_present_but_tls_false` locks the strict no-fallback decision.
-- **Type consistency:** the config key is `tls` (boolean) everywhere — config.yaml options, schema, `self.config.get("tls")`, and all tests.
+- **Type consistency:** the config key is `tls` (boolean) everywhere — config.yaml options, add-on schema, JSON schema, `self.config.get("tls")`, and all tests.
+- **Schema scope:** `config.schema.json` validates the runtime config (template / `/data/options.json`), mirroring `config_validation.py`; the HA add-on manifest keeps its own `schema:` block in `config.yaml`.
 - **Port unchanged:** no task modifies the default `1883`; docs only mention `8883` as a manual choice.

--- a/smartmeter/CHANGELOG.md
+++ b/smartmeter/CHANGELOG.md
@@ -2,12 +2,23 @@
 
 ## [Unreleased]
 
+**Fixed bugs:**
+
+- MQTT no longer attempts a TLS handshake on the plain `1883` port. TLS
+  was previously force-enabled by the `tls_insecure: false` default,
+  causing `[SSL: UNEXPECTED_EOF_WHILE_READING]` connection failures
+  ([\#94](https://github.com/r00tat/smartmeter_homeassistant_burgenland/issues/94)).
+
 **Implemented enhancements:**
 
 - Add support for Netz Niederösterreich / EVN Sagemcom T210-D meter
   (M-Bus framing, 2400 8E1, AES-GCM). Select via `meter_type: noe_evn`.
   Existing Netz Burgenland (`burgenland`) deployments keep their current
   behaviour as the default profile.
+- Add explicit `mqtt.tls` option. TLS is now opt-in via `tls: true`; the
+  `tls_ca` / `tls_cert` / `tls_key` / `tls_insecure` options only apply
+  when TLS is enabled. A JSON Schema (`config.schema.json`) is provided
+  for validating configuration files.
 
 ## [0.6.0](https://github.com/r00tat/smartmeter_homeassistant_burgenland/tree/0.6.0) (2026-04-17)
 

--- a/smartmeter/DOCS.md
+++ b/smartmeter/DOCS.md
@@ -34,4 +34,21 @@ T210-D does not publish them.
 
 ## Optional MQTT TLS
 
-To connect to an MQTT broker over TLS, set any of the `tls_ca`, `tls_cert`, `tls_key`, or `tls_insecure` options under `mqtt`. `tls_ca` points to a CA certificate (PEM) the broker is trusted against; `tls_cert` and `tls_key` enable mutual TLS with a client certificate and key. Set `tls_insecure: true` to skip hostname verification for testing only. Paths must be readable from within the addon container (e.g. mounted via `share:ro` or `config:ro`). If none of these options are set, MQTT connects without TLS.
+TLS is disabled by default. To connect to an MQTT broker over TLS, set
+`tls: true` under `mqtt`. The default port stays `1883`; TLS brokers
+usually listen on a separate port (commonly `8883`), so set `port`
+accordingly.
+
+When `tls: true`, the following options take effect (they are ignored
+while `tls` is `false`):
+
+- `tls_ca`: path to a CA certificate (PEM) the broker is trusted against.
+  If left empty, the system CA store is used (works with publicly trusted
+  brokers).
+- `tls_cert` and `tls_key`: enable mutual TLS with a client certificate
+  and key.
+- `tls_insecure: true`: skip hostname/certificate verification (testing
+  only).
+
+Certificate paths must be readable from within the add-on container (e.g.
+mounted via `share:ro` or `config:ro`).

--- a/smartmeter/config.schema.json
+++ b/smartmeter/config.schema.json
@@ -4,6 +4,7 @@
   "title": "Smartmeter add-on runtime configuration",
   "type": "object",
   "additionalProperties": true,
+  "required": ["mqtt", "dlms"],
   "properties": {
     "logging": {
       "type": "string",

--- a/smartmeter/config.schema.json
+++ b/smartmeter/config.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/r00tat/smartmeter_homeassistant_burgenland/config.schema.json",
+  "title": "Smartmeter add-on runtime configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "logging": {
+      "type": "string",
+      "enum": ["INFO", "WARNING", "ERROR", "CRITICAL", "DEBUG"]
+    },
+    "meter_type": {
+      "type": "string",
+      "enum": ["burgenland", "noe_evn"],
+      "default": "burgenland"
+    },
+    "interface_type": {
+      "type": "string",
+      "enum": ["OPTICAL", "PHYSICAL"]
+    },
+    "mqtt": {
+      "type": "object",
+      "required": ["host"],
+      "additionalProperties": false,
+      "properties": {
+        "device_id": {"type": "string"},
+        "name": {"type": "string"},
+        "host": {"type": "string", "minLength": 1},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "user": {"type": "string"},
+        "password": {"type": "string"},
+        "keepalive": {"type": "integer", "minimum": 1},
+        "prefix": {"type": "string"},
+        "sensors_migrated": {"type": "boolean"},
+        "publish_interval": {"type": "integer", "minimum": 1},
+        "tls": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable MQTT over TLS. The tls_* options apply only when true."
+        },
+        "tls_ca": {"type": "string"},
+        "tls_cert": {"type": "string"},
+        "tls_key": {"type": "string"},
+        "tls_insecure": {"type": "boolean"}
+      }
+    },
+    "dlms": {
+      "type": "object",
+      "required": ["key", "port"],
+      "additionalProperties": false,
+      "properties": {
+        "port": {"type": "string", "minLength": 1},
+        "baudrate": {"type": "integer"},
+        "bytesize": {"type": "integer"},
+        "parity": {
+          "type": "string",
+          "enum": ["NONE", "EVEN", "ODD", "MARK", "SPACE"]
+        },
+        "stopbits": {"type": "integer"},
+        "key": {"type": "string", "pattern": "^[0-9a-fA-F]{32}$"},
+        "hdlc_frame_size": {"type": "integer"}
+      }
+    }
+  }
+}

--- a/smartmeter/config.schema.json
+++ b/smartmeter/config.schema.json
@@ -54,7 +54,10 @@
         "bytesize": {"type": "integer"},
         "parity": {
           "type": "string",
-          "enum": ["NONE", "EVEN", "ODD", "MARK", "SPACE"]
+          "enum": [
+            "", "NONE", "EVEN", "ODD", "MARK", "SPACE",
+            "N", "E", "O", "M", "S"
+          ]
         },
         "stopbits": {"type": "integer"},
         "key": {"type": "string", "pattern": "^[0-9a-fA-F]{32}$"},

--- a/smartmeter/config.yaml
+++ b/smartmeter/config.yaml
@@ -31,6 +31,7 @@ options:
     prefix: ""
     sensors_migrated: false
     publish_interval: 30
+    tls: false
     tls_ca: ""
     tls_cert: ""
     tls_key: ""
@@ -58,6 +59,7 @@ schema:
     prefix: "str?"
     sensors_migrated: bool?
     publish_interval: int?
+    tls: bool?
     tls_ca: "str?"
     tls_cert: "str?"
     tls_key: "str?"

--- a/smartmeter/meter/mqtt/client.py
+++ b/smartmeter/meter/mqtt/client.py
@@ -44,17 +44,14 @@ class MqttClient:
         )
 
     def _configure_tls(self) -> None:
-        """Enable TLS if any tls_* option is present in the config."""
+        """Enable TLS only when explicitly switched on via ``tls: true``."""
+        if not self.config.get("tls"):
+            return
+
         tls_ca = self.config.get("tls_ca")
         tls_cert = self.config.get("tls_cert")
         tls_key = self.config.get("tls_key")
         tls_insecure = self.config.get("tls_insecure")
-
-        if not any(
-            value not in (None, "")
-            for value in (tls_ca, tls_cert, tls_key, tls_insecure)
-        ):
-            return
 
         log.info("enabling MQTT TLS")
         self.client.tls_set(

--- a/smartmeter/requirements-dev.txt
+++ b/smartmeter/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+jsonschema~=4.0
 mypy~=2.1
 pytest~=9.0
 ruff~=0.15.14

--- a/smartmeter/smartmeter-config-template.yaml
+++ b/smartmeter/smartmeter-config-template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./config.schema.json
 logging: INFO
 # meter_type selects the provider profile. Supported:
 #   burgenland (default) — Landis+Gyr E450 via DLMS/HDLC (Netz Burgenland)

--- a/smartmeter/smartmeter-config.example.yaml
+++ b/smartmeter/smartmeter-config.example.yaml
@@ -9,7 +9,7 @@ interface_type: OPTICAL
 mqtt:
   # device_id: "smartmeter"
   # name: "Smart Meter"
-  host: ""
+  host: "example.com"
   # port: 1883
   user: ""
   password: ""
@@ -22,4 +22,4 @@ dlms:
   # bytesize: 8
   # parity: "NONE"
   # stopbits: 1
-  key: "" # hex key to decrypt message
+  key: "012345678901234567890123456789ab" # hex key to decrypt message

--- a/smartmeter/tests/test_config_schema.py
+++ b/smartmeter/tests/test_config_schema.py
@@ -1,0 +1,47 @@
+"""The runtime config schema accepts the template and the mqtt.tls option."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import yaml
+from jsonschema import Draft202012Validator
+
+_HERE = os.path.dirname(os.path.dirname(__file__))  # smartmeter/
+_SCHEMA = os.path.join(_HERE, "config.schema.json")
+_TEMPLATE = os.path.join(_HERE, "smartmeter-config-template.yaml")
+
+
+def _schema() -> dict:
+    with open(_SCHEMA, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_schema_is_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(_schema())
+
+
+def test_template_matches_schema() -> None:
+    with open(_TEMPLATE, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    # template ships an empty host/key (user fills them); validate shape only
+    data.setdefault("mqtt", {})["host"] = "mqtt.local"
+    data.setdefault("dlms", {})["key"] = "00" * 16
+    Draft202012Validator(_schema()).validate(data)
+
+
+def test_schema_allows_tls_boolean() -> None:
+    schema = _schema()
+    mqtt_props = schema["properties"]["mqtt"]["properties"]
+    assert mqtt_props["tls"]["type"] == "boolean"
+
+
+def test_schema_rejects_unknown_meter_type() -> None:
+    cfg = {
+        "meter_type": "bogus",
+        "mqtt": {"host": "h"},
+        "dlms": {"key": "00" * 16, "port": "/dev/ttyUSB0"},
+    }
+    errors = list(Draft202012Validator(_schema()).iter_errors(cfg))
+    assert errors, "unknown meter_type should fail validation"

--- a/smartmeter/tests/test_config_schema.py
+++ b/smartmeter/tests/test_config_schema.py
@@ -10,7 +10,7 @@ from jsonschema import Draft202012Validator
 
 _HERE = os.path.dirname(os.path.dirname(__file__))  # smartmeter/
 _SCHEMA = os.path.join(_HERE, "config.schema.json")
-_TEMPLATE = os.path.join(_HERE, "smartmeter-config-template.yaml")
+_TEMPLATE = os.path.join(_HERE, "smartmeter-config.example.yaml")
 
 
 def _schema() -> dict:

--- a/smartmeter/tests/test_config_schema.py
+++ b/smartmeter/tests/test_config_schema.py
@@ -22,12 +22,11 @@ def test_schema_is_valid_draft_2020_12() -> None:
     Draft202012Validator.check_schema(_schema())
 
 
-def test_template_matches_schema() -> None:
+def test_example_config_matches_schema() -> None:
+    # The shipped example config must validate as-is: it carries placeholder
+    # values (host, 32-hex key) so users get no editor errors before editing.
     with open(_TEMPLATE, encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
-    # template ships an empty host/key (user fills them); validate shape only
-    data.setdefault("mqtt", {})["host"] = "mqtt.local"
-    data.setdefault("dlms", {})["key"] = "00" * 16
     Draft202012Validator(_schema()).validate(data)
 
 

--- a/smartmeter/tests/test_config_schema.py
+++ b/smartmeter/tests/test_config_schema.py
@@ -45,3 +45,13 @@ def test_schema_rejects_unknown_meter_type() -> None:
     }
     errors = list(Draft202012Validator(_schema()).iter_errors(cfg))
     assert errors, "unknown meter_type should fail validation"
+
+
+def test_schema_accepts_single_letter_parity() -> None:
+    # config_validation.py accepts both pyserial letters and full names.
+    cfg = {
+        "mqtt": {"host": "h"},
+        "dlms": {"key": "00" * 16, "port": "/dev/ttyUSB0", "parity": "E"},
+    }
+    errors = list(Draft202012Validator(_schema()).iter_errors(cfg))
+    assert not errors, f"single-letter parity should be valid: {errors}"

--- a/smartmeter/tests/test_mqtt_tls.py
+++ b/smartmeter/tests/test_mqtt_tls.py
@@ -21,18 +21,21 @@ def test_tls_not_enabled_when_key_absent() -> None:
     # Regression for #94: default config has no `tls` key.
     client = _make_client({})
     client.tls_set.assert_not_called()
+    client.tls_insecure_set.assert_not_called()
 
 
 def test_tls_not_enabled_when_false_with_insecure_false() -> None:
     # The exact #94 trigger: tls_insecure default False must not enable TLS.
     client = _make_client({"tls": False, "tls_insecure": False})
     client.tls_set.assert_not_called()
+    client.tls_insecure_set.assert_not_called()
 
 
 def test_tls_not_enabled_when_certs_present_but_tls_false() -> None:
     # No fallback: certs alone do not enable TLS.
     client = _make_client({"tls": False, "tls_ca": "/config/ca.pem"})
     client.tls_set.assert_not_called()
+    client.tls_insecure_set.assert_not_called()
 
 
 def test_tls_enabled_without_certs_uses_system_ca() -> None:
@@ -40,6 +43,12 @@ def test_tls_enabled_without_certs_uses_system_ca() -> None:
     client.tls_set.assert_called_once_with(
         ca_certs=None, certfile=None, keyfile=None
     )
+
+
+def test_tls_enabled_does_not_set_insecure_when_absent() -> None:
+    client = _make_client({"tls": True, "tls_ca": "/config/ca.pem"})
+    client.tls_set.assert_called_once()
+    client.tls_insecure_set.assert_not_called()
 
 
 def test_tls_enabled_with_ca_and_insecure() -> None:

--- a/smartmeter/tests/test_mqtt_tls.py
+++ b/smartmeter/tests/test_mqtt_tls.py
@@ -1,0 +1,60 @@
+"""Tests for MqttClient._configure_tls TLS gating (issue #94)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from meter.mqtt.client import MqttClient
+
+
+def _make_client(mqtt_cfg: dict) -> MagicMock:
+    """Instantiate MqttClient with paho Client patched; return the mock client."""
+    cfg = {"host": "mqtt.local", **mqtt_cfg}
+    with patch("meter.mqtt.client.mqtt.Client") as client_cls:
+        client_instance = MagicMock()
+        client_cls.return_value = client_instance
+        MqttClient(cfg)
+    return client_instance
+
+
+def test_tls_not_enabled_when_key_absent() -> None:
+    # Regression for #94: default config has no `tls` key.
+    client = _make_client({})
+    client.tls_set.assert_not_called()
+
+
+def test_tls_not_enabled_when_false_with_insecure_false() -> None:
+    # The exact #94 trigger: tls_insecure default False must not enable TLS.
+    client = _make_client({"tls": False, "tls_insecure": False})
+    client.tls_set.assert_not_called()
+
+
+def test_tls_not_enabled_when_certs_present_but_tls_false() -> None:
+    # No fallback: certs alone do not enable TLS.
+    client = _make_client({"tls": False, "tls_ca": "/config/ca.pem"})
+    client.tls_set.assert_not_called()
+
+
+def test_tls_enabled_without_certs_uses_system_ca() -> None:
+    client = _make_client({"tls": True})
+    client.tls_set.assert_called_once_with(
+        ca_certs=None, certfile=None, keyfile=None
+    )
+
+
+def test_tls_enabled_with_ca_and_insecure() -> None:
+    client = _make_client(
+        {
+            "tls": True,
+            "tls_ca": "/config/ca.pem",
+            "tls_cert": "/config/client.pem",
+            "tls_key": "/config/client.key",
+            "tls_insecure": True,
+        }
+    )
+    client.tls_set.assert_called_once_with(
+        ca_certs="/config/ca.pem",
+        certfile="/config/client.pem",
+        keyfile="/config/client.key",
+    )
+    client.tls_insecure_set.assert_called_once_with(True)


### PR DESCRIPTION
## Summary

Fixes #94. MQTT TLS was force-enabled on the plain `1883` port, causing `[SSL: UNEXPECTED_EOF_WHILE_READING]`. Root cause: `_configure_tls()` enabled TLS whenever any `tls_*` value was "non-empty", and the shipped default `tls_insecure: false` satisfied that check (`False not in (None, "")` is `True`), so TLS was always on.

## Changes

**TLS fix + opt-in config**
- `_configure_tls()` now enables TLS **only** when the explicit boolean `mqtt.tls` is true — no fallback from certificate presence. The `tls_ca` / `tls_cert` / `tls_key` / `tls_insecure` options apply only when TLS is on.
- Added `tls` (default `false`) to the add-on `options` + `schema` in `config.yaml`.
- 6 regression/behaviour tests for the TLS gate (including the exact #94 trigger).

**Runtime config JSON Schema**
- New `smartmeter/config.schema.json` (Draft 2020-12) describing the runtime config, mirroring `config_validation.py` (meter_type / parity enums, required `mqtt.host` & `dlms.key`, 32-hex key pattern) and including `mqtt.tls`. Top-level `mqtt`/`dlms` required.
- `# yaml-language-server: $schema=./config.schema.json` header in the example config; `jsonschema` added as a dev dependency; 5 schema tests.

**Editor / housekeeping**
- Renamed `smartmeter-config-template.yaml` → `smartmeter-config.example.yaml` so editors no longer mis-detect it as an AWS CloudFormation template (`*template.yaml`). Updated README, tests, and `.vscode/settings.json`.
- The example config now ships valid placeholder values (`host`, 32-hex key) so it validates against the schema with no editor warnings.

**Docs**
- `DOCS.md`: TLS is now opt-in via `tls: true`; default port stays `1883` (TLS brokers usually use a separate port such as `8883`).
- `CHANGELOG.md`: bugfix + enhancement entries under `[Unreleased]`.

## Testing
- `python -m pytest tests/` → 72 passed
- `ruff check meter tests` → clean

Design & plan: `docs/plans/2026-05-31-mqtt-tls-config-design.md`, `docs/plans/2026-05-31-mqtt-tls-config-plan.md`.