### PR TITLE
fix(noe): normalize parity name to pyserial letter code (#97)

### DIFF
--- a/smartmeter/meter/noe/read.py
+++ b/smartmeter/meter/noe/read.py
@@ -33,6 +33,9 @@ _MIN_FRAME_LENGTH = 27  # must fit system title and frame counter
 _MAX_CONSECUTIVE_FAILURES = 10
 _DATA_NOTIFICATION_TAG = 0x0F
 
+_PARITY_LETTERS = serial.PARITY_NAMES.keys()
+_PARITY_NAME_TO_LETTER = {v.upper(): k for k, v in serial.PARITY_NAMES.items()}
+
 
 class _SerialLike(Protocol):
     def read(self, size: int = 1) -> bytes: ...
@@ -58,7 +61,13 @@ class NoeMeterReader:
         self.port = port
         self.baudrate = baudrate
         self.bytesize = bytesize
+        # Config supplies human-readable names ("NONE"); pyserial wants the
+        # single-letter codes ("N"). Normalise, falling back to no parity.
         self.parity = parity
+        if self.parity not in _PARITY_LETTERS:
+            self.parity = _PARITY_NAME_TO_LETTER.get(
+                str(parity).upper(), serial.PARITY_NONE
+            )
         self.stopbits = stopbits
         self.timeout = timeout
         self.callback = callback

--- a/smartmeter/tests/test_noe_reader.py
+++ b/smartmeter/tests/test_noe_reader.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 from collections import deque
 from threading import Thread
 
+import pytest
+import serial
+
 from meter.noe.data import MeterData
 from meter.noe.read import NoeMeterReader
 from tests.fixtures.noe_sample_frame import build_sample_frame
@@ -69,6 +72,27 @@ def test_reader_invokes_callback_with_decoded_meter_data() -> None:
     assert data.current_l1 == 5.0
     assert data.power_factor == 0.98
     assert data.total_consumed == 12345678
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [
+        ("NONE", serial.PARITY_NONE),
+        ("none", serial.PARITY_NONE),
+        ("EVEN", serial.PARITY_EVEN),
+        ("Odd", serial.PARITY_ODD),
+        ("N", serial.PARITY_NONE),
+        ("E", serial.PARITY_EVEN),
+    ],
+)
+def test_reader_normalizes_parity_name_to_pyserial_letter(given, expected) -> None:
+    """Config supplies human-readable parity names; pyserial wants letters.
+
+    Regression test for issue #97: ``parity="NONE"`` crashed ``serial.Serial``
+    with ``ValueError: Not a valid parity: 'NONE'``.
+    """
+    reader = NoeMeterReader(key_hex="00" * 16, parity=given)
+    assert reader.parity == expected
 
 
 def test_reader_skips_garbage_until_mbus_start() -> None:


### PR DESCRIPTION
## Problem

Closes #97 ("EVN Parity").

The NÖ/EVN reader (`meter_type: noe_evn`) passed the human-readable parity **name** from the config (`"NONE"`) straight to `serial.Serial(...)`. pyserial only accepts the single-letter codes `N/E/O/M/S`, so it crashed on startup:

```
ValueError: Not a valid parity: 'NONE'
```

Since `parity: "NONE"` is the shipped default, every `noe_evn` user hit this. The Burgenland serial reader already normalizes names → letters; the NÖ/EVN reader was missing that step.

## Fix

- Normalize the parity value in `NoeMeterReader.__init__` (`"NONE"` → `"N"`), mirroring the existing logic in `meter/serial/read.py`, with a fallback to `PARITY_NONE`.
- Add a parametrized regression test (`NONE/none/EVEN/Odd/N/E`).

## Verification

- New test fails before the fix, passes after.
- Full suite: **78 passed**.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)