### PR TITLE
fix(dlms): force HDLC framing to avoid gurux wireless M-Bus crash (#98)

### DIFF
--- a/smartmeter/meter/dlms/read.py
+++ b/smartmeter/meter/dlms/read.py
@@ -44,6 +44,13 @@ def parse_pyhiscal_dlms_data(data: bytes, key: str):
     tr.comments = True
     msg = GXDLMSTranslatorMessage()
     msg.message = GXByteBuffer(data)
+    # Pin the framing to HDLC. Without this, ``interfaceType`` stays ``None`` and
+    # ``findNextFrame`` scans the buffer trying every framing; a misaligned byte
+    # can match ``isWirelessMBusData`` and enter the wireless M-Bus branch, which
+    # calls the broken ``_GXCommon.decryptManufacturer`` (removed in gurux-dlms
+    # >= 1.0.193) and raises AttributeError. Our serial meters are always HDLC.
+    # See https://github.com/r00tat/smartmeter_homeassistant_burgenland/issues/98
+    msg.interfaceType = InterfaceType.HDLC
     xml = ""
     pdu = GXByteBuffer()
     tr.completePdu = True

--- a/smartmeter/requirements.txt
+++ b/smartmeter/requirements.txt
@@ -1,4 +1,4 @@
-gurux-common~=1.0.13
+gurux-common==1.0.13
 gurux-dlms==1.0.197
 paho-mqtt~=2.1.0
 pycryptodomex~=3.20

--- a/smartmeter/tests/test_dlms_read.py
+++ b/smartmeter/tests/test_dlms_read.py
@@ -1,0 +1,67 @@
+"""Regression tests for meter.dlms.read."""
+
+from gurux_dlms import GXByteBuffer, GXDLMSTranslator, GXDLMSTranslatorMessage
+from gurux_dlms.enums import InterfaceType
+
+from meter.dlms.read import parse_pyhiscal_dlms_data
+
+# A dummy 128-bit key (hex). The crash happens during frame detection, long
+# before any decryption, so the key value is irrelevant here.
+DUMMY_KEY = "00112233445566778899AABBCCDDEEFF"
+
+# Buffer whose 2nd byte (0x04 = MBusCommand.SND_NR) makes gurux's
+# isWirelessMBusData() return True, while the 1st byte (0x00) is not an
+# HDLC/WRAPPER/PLC/wired-MBus start. While scanning a real HDLC stream,
+# findNextFrame lands on such misaligned positions. With an unset interface
+# type it then enters the wireless M-Bus branch, which calls the removed
+# _GXCommon.decryptManufacturer() (gurux-dlms >= 1.0.193) and raises
+# AttributeError. See issue #98.
+WIRELESS_MBUS_TRIGGER = bytes(
+    [0x00, 0x04, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xA0]
+)
+
+
+def test_parse_physical_does_not_enter_wireless_mbus_branch():
+    """parse_pyhiscal_dlms_data must not crash on wireless-M-Bus-looking bytes."""
+    # Must not raise AttributeError: '_GXCommon' has no 'decryptManufacturer'.
+    result = parse_pyhiscal_dlms_data(WIRELESS_MBUS_TRIGGER, DUMMY_KEY)
+    assert isinstance(result, str)
+
+
+def test_unpinned_interface_type_still_reproduces_the_crash():
+    """Guards the assumption behind the fix.
+
+    Leaving interfaceType unset (the pre-fix behaviour) still triggers the gurux
+    wireless-M-Bus code path. If a future gurux release fixes the bug this test
+    will start failing, signalling that the workaround in
+    parse_pyhiscal_dlms_data can be revisited.
+    """
+
+    tr = GXDLMSTranslator()
+    tr.comments = True
+    tr.completePdu = True
+    msg = GXDLMSTranslatorMessage()
+    msg.message = GXByteBuffer(WIRELESS_MBUS_TRIGGER)
+    pdu = GXByteBuffer()
+
+    crashed = False
+    try:
+        while tr.findNextFrame(msg, pdu):
+            pdu.clear()
+            tr.messageToXml(msg)
+    except AttributeError as exc:
+        crashed = "decryptManufacturer" in str(exc)
+
+    # Forcing HDLC avoids exactly this branch.
+    msg2 = GXDLMSTranslatorMessage()
+    msg2.message = GXByteBuffer(WIRELESS_MBUS_TRIGGER)
+    msg2.interfaceType = InterfaceType.HDLC
+    pdu2 = GXByteBuffer()
+    while tr.findNextFrame(msg2, pdu2):
+        pdu2.clear()
+        tr.messageToXml(msg2)
+
+    assert crashed, (
+        "expected the unpinned interfaceType to hit the wireless M-Bus branch; "
+        "if gurux-dlms fixed the bug, the workaround can be removed"
+    )


### PR DESCRIPTION
## Problem

Reading from the serial smart meter crashes intermittently (issue #98):

```
AttributeError: type object '_GXCommon' has no attribute 'decryptManufacturer'.
Did you mean: 'encryptManufacturer'?
  File ".../gurux_dlms/GXDLMS.py", line 1457, in __getWirelessMBusData
    man = _GXCommon.decryptManufacturer(manufacturerID)
```

## Root cause

This is **not** a `gurux-common` problem — the `_GXCommon` in the traceback is `gurux_dlms.internal._GXCommon`. It's a regression inside `gurux-dlms`:

- In gurux-dlms **≤ 1.0.192**, `_GXCommon` defines `decryptManufacturer`.
- In **1.0.193** the method was removed, but `GXDLMS.py` still calls it. Still missing in the latest **1.0.198**.

The broken branch is only reached because `parse_pyhiscal_dlms_data` lets `GXDLMSTranslator.findNextFrame` **auto-detect** the framing. While scanning the HDLC byte stream, a misaligned byte occasionally satisfies `isWirelessMBusData()`, the translator enters the wireless M-Bus branch, and hits the missing method.

## Fix

Force `msg.interfaceType = InterfaceType.HDLC` in `parse_pyhiscal_dlms_data`. With the framing pinned, every non-HDLC branch guard (`... in (None, X)`) excludes it, so the broken wireless M-Bus path is never entered — **independent of the gurux-dlms version**. This path is only used by the serial HDLC meters; the NOE/Sagemcom reader uses `pduToXml` and is unaffected.

`gurux-common` is also pinned to an exact version for reproducible builds.

## Verification

- Reproduced the exact `AttributeError` against the installed (broken) gurux-dlms 1.0.197 with default framing, and confirmed forcing HDLC stops it.
- Added `tests/test_dlms_read.py` — verified it **fails without the fix** and passes with it. A second test will start failing if upstream ever fixes the bug, signalling the workaround can be removed.
- `ruff` clean; full suite: **81 passed**.

Fixes #98