### PR TITLE
fix(noe): survive serial timeouts, reconnect on faults, add diagnostics

### DIFF
--- a/smartmeter/meter/noe/read.py
+++ b/smartmeter/meter/noe/read.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from time import sleep
+from time import monotonic, sleep
 from typing import Protocol
 
 import serial
@@ -32,6 +32,8 @@ _STOP_BYTE = 0x16
 _MIN_FRAME_LENGTH = 27  # must fit system title and frame counter
 _MAX_CONSECUTIVE_FAILURES = 10
 _DATA_NOTIFICATION_TAG = 0x0F
+_HEARTBEAT_SECONDS = 30.0  # how often to emit a reader stats line
+_RECONNECT_BACKOFF_SECONDS = 5.0  # wait before reopening the port after a fault
 
 _PARITY_LETTERS = serial.PARITY_NAMES.keys()
 _PARITY_NAME_TO_LETTER = {v.upper(): k for k, v in serial.PARITY_NAMES.items()}
@@ -56,6 +58,7 @@ class NoeMeterReader:
         timeout: float = 1.0,
         callback: Callable[[MeterData], None] | None = None,
         serial_factory: Callable[[], _SerialLike] | None = None,
+        monotonic: Callable[[], float] = monotonic,
     ) -> None:
         self.key = bytes.fromhex(key_hex)
         self.port = port
@@ -76,6 +79,18 @@ class NoeMeterReader:
         self.ser: _SerialLike | None = None
         self.should_run = True
         self.is_running = False
+        self.reconnect_backoff_seconds = _RECONNECT_BACKOFF_SECONDS
+
+        # Diagnostic counters surfaced in the periodic heartbeat so a failed
+        # run produces actionable logs (no bytes vs. no sync vs. no decode).
+        self._monotonic = monotonic
+        self._bytes_read = 0
+        self._sync_hits = 0
+        self._frames_parsed = 0
+        self._frames_decoded = 0
+        self._frame_failures = 0
+        self._last_frame_at: float | None = None
+        self._last_heartbeat = 0.0
 
     def connect(self) -> None:
         if self._serial_factory is not None:
@@ -103,10 +118,29 @@ class NoeMeterReader:
             self.ser = None
 
     def start(self) -> None:
+        """Supervise the read loop, reconnecting on faults until stopped.
+
+        A serial fault or a burst of frame failures no longer kills the
+        thread (and with it the whole add-on): the port is reopened after a
+        short backoff and reading resumes. Only ``stop()`` ends the loop.
+        """
         self.is_running = True
-        self.connect()
+        self._last_heartbeat = self._monotonic()
         try:
-            self._read_loop()
+            while self.should_run:
+                try:
+                    self.connect()
+                    self._read_loop()
+                except (serial.SerialException, OSError) as exc:
+                    log.exception("serial port error on %s: %s", self.port, exc)
+                finally:
+                    self.disconnect()
+                if self.should_run:
+                    log.warning(
+                        "reader interrupted, reconnecting in %.1fs",
+                        self.reconnect_backoff_seconds,
+                    )
+                    sleep(self.reconnect_backoff_seconds)
         finally:
             self.is_running = False
             self.disconnect()
@@ -118,22 +152,26 @@ class NoeMeterReader:
         assert self.ser is not None
         failures = 0
         while self.should_run:
+            self._maybe_heartbeat()
             frame = self._read_frame()
             if frame is None:
-                # EOF or stopped
+                # Only reached on shutdown (``should_run`` cleared).
                 return
             try:
                 self._handle_frame(frame)
                 failures = 0
             except (MBusFrameError, DecryptionError, ValueError) as exc:
                 failures += 1
+                self._frame_failures += 1
                 log.exception("failed to handle frame: %s", exc)
                 if failures >= _MAX_CONSECUTIVE_FAILURES:
+                    # Return (not raise) so ``start()`` reconnects instead of
+                    # tearing the thread — and the whole app — down.
                     log.error(
-                        "exceeded %d consecutive failures, aborting",
+                        "exceeded %d consecutive failures, reconnecting",
                         _MAX_CONSECUTIVE_FAILURES,
                     )
-                    raise
+                    return
 
     def _read_frame(self) -> bytes | None:
         """Synchronise on the next M-Bus long frame and return its bytes."""
@@ -144,7 +182,13 @@ class NoeMeterReader:
         while self.should_run:
             byte = self.ser.read(1)
             if not byte:
-                return None
+                # Empty read is a serial *timeout* (no byte arrived within
+                # ``self.timeout``), not end-of-stream. The meter pushes a
+                # frame only every few seconds, so keep waiting instead of
+                # tearing the reader down and shutting the whole app off.
+                self._maybe_heartbeat()
+                continue
+            self._bytes_read += len(byte)
             header += byte
             if len(header) > 4:
                 header.pop(0)
@@ -159,41 +203,88 @@ class NoeMeterReader:
         else:
             return None
 
+        self._sync_hits += 1
         length = header[1]
+        log.debug("synced on M-Bus long frame, user-data length %d", length)
         remaining = length + 2  # user data + CS + stop byte
         body = bytearray()
         while self.should_run and len(body) < remaining:
             chunk = self.ser.read(remaining - len(body))
             if not chunk:
-                return None
+                # Timeout mid-frame; keep reading until the rest arrives.
+                continue
+            self._bytes_read += len(chunk)
             body += chunk
         if len(body) < remaining:
+            # Loop only exits short when ``should_run`` flipped (shutdown).
             return None
         if body[-1] != _STOP_BYTE:
             raise MBusFrameError(f"missing trailer byte 0x16, got {body[-1]:#04x}")
         return bytes(header) + bytes(body)
 
     def _handle_frame(self, raw_frame: bytes) -> None:
+        log.debug("raw frame (%d bytes): %s", len(raw_frame), raw_frame.hex())
         parsed = MBusFrame.parse(raw_frame.hex())
+        self._frames_parsed += 1
         nonce = parsed.system_title + parsed.frame_counter
         apdu = aes_gcm_decrypt(parsed.ciphertext, self.key, nonce)
         if not apdu or apdu[0] != _DATA_NOTIFICATION_TAG:
+            # Wrong key produces garbage here (the on-wire layout omits the
+            # GCM tag, so decryption itself cannot fail) — the heartbeat's
+            # "frames but no decodes" hint points at the key.
             log.debug(
-                "apdu does not start with data-notification tag 0x0F, skipping"
+                "apdu does not start with data-notification tag 0x0F "
+                "(got %s), skipping — check the decryption key",
+                f"{apdu[0]:#04x}" if apdu else "empty",
             )
             return
         xml = self._translator.pduToXml(apdu.hex())
         obis_values = parse_obis_xml(xml)
         data = MeterData(obis_values)
+        self._frames_decoded += 1
+        self._last_frame_at = self._monotonic()
         log.debug("decoded meter data: %s", data)
         if self.callback is not None:
             self.callback(data)
 
-    SHUTDOWN_GRACE_SECONDS = 2.5
+    def _maybe_heartbeat(self) -> None:
+        """Emit a periodic stats line so a stalled run is diagnosable."""
+        now = self._monotonic()
+        if now - self._last_heartbeat < _HEARTBEAT_SECONDS:
+            return
+        self._last_heartbeat = now
+        if self._last_frame_at is not None:
+            age = f"{now - self._last_frame_at:.0f}s ago"
+        else:
+            age = "never"
+        log.info(
+            "reader heartbeat — bytes:%d syncs:%d frames:%d decoded:%d "
+            "failures:%d (last frame: %s)",
+            self._bytes_read,
+            self._sync_hits,
+            self._frames_parsed,
+            self._frames_decoded,
+            self._frame_failures,
+            age,
+        )
+        hint = self._diagnostic_hint()
+        if hint:
+            log.warning("reader diagnostic: %s", hint)
 
-    def recover(self) -> None:
-        """Match the reference script's sleep-and-reopen recovery."""
-        log.warning("recovering serial port after failure")
-        self.disconnect()
-        sleep(self.SHUTDOWN_GRACE_SECONDS)
-        self.connect()
+    def _diagnostic_hint(self) -> str | None:
+        """Map the current counters to a likely root cause, or ``None``."""
+        if self._frames_decoded > 0:
+            return None
+        if self._bytes_read == 0:
+            return (
+                "no bytes received — check wiring, serial port, baudrate "
+                "and parity"
+            )
+        if self._sync_hits == 0:
+            return (
+                "bytes received but no M-Bus frame sync (68 LL LL 68) — "
+                "check baudrate/parity and that this is a Sagemcom T210-D"
+            )
+        return (
+            "frames received but none decoded — check the decryption key"
+        )

--- a/smartmeter/meter/smartmeter.py
+++ b/smartmeter/meter/smartmeter.py
@@ -56,8 +56,8 @@ class SmartMqttMeter:
             profile,
             callback=self.got_meter_data,
         )
-        log.info("connecting to serial port")
-        self.reader.connect()
+        # The reader opens the port itself in ``start()``; opening it here too
+        # left two handles on the same device (and logged the connect twice).
 
         mqtt_config = self.config.get("mqtt", {})
         log.info("mqtt config: \n%s", yaml.safe_dump(_redact(mqtt_config)))

--- a/smartmeter/tests/test_noe_reader.py
+++ b/smartmeter/tests/test_noe_reader.py
@@ -7,6 +7,7 @@ through the reader and asserts that the callback receives a populated
 
 from __future__ import annotations
 
+import logging
 from collections import deque
 from threading import Thread
 
@@ -95,6 +96,55 @@ def test_reader_normalizes_parity_name_to_pyserial_letter(given, expected) -> No
     assert reader.parity == expected
 
 
+class TimeoutThenFrameSerial(FakeSerial):
+    """Serial stub that times out (empty reads) before delivering a frame.
+
+    Real pyserial returns ``b""`` from ``read()`` whenever the configured
+    ``timeout`` elapses without a byte arriving -- which happens constantly
+    between frames and in the window after connecting, before the meter
+    pushes its first frame. An empty read is a *timeout*, not end-of-stream,
+    and must not terminate the reader.
+    """
+
+    def __init__(self, payload: bytes, timeouts_before: int = 3) -> None:
+        super().__init__(payload)
+        self._timeouts_before = timeouts_before
+
+    def read(self, size: int = 1) -> bytes:
+        if self._timeouts_before > 0:
+            self._timeouts_before -= 1
+            return b""
+        return super().read(size)
+
+
+def test_reader_survives_serial_timeouts_before_first_frame() -> None:
+    """Regression test for issue #97 (second report).
+
+    The reader exited on the first serial timeout, shutting the whole app
+    down without reading a single frame and without crashing.
+    """
+    sample = build_sample_frame()
+    payload = bytes.fromhex(sample.frame_hex)
+
+    received: list[MeterData] = []
+
+    def callback(data: MeterData) -> None:
+        received.append(data)
+        reader.stop()
+
+    reader = NoeMeterReader(
+        key_hex=sample.key.hex(),
+        serial_factory=lambda: TimeoutThenFrameSerial(payload + b"\x00" * 64),
+        callback=callback,
+    )
+
+    thread = Thread(target=reader.start)
+    thread.start()
+    thread.join(timeout=5.0)
+    assert not thread.is_alive(), "reader did not terminate"
+    assert len(received) == 1, "reader exited on a timeout instead of reading the frame"
+
+
 def test_reader_skips_garbage_until_mbus_start() -> None:
     sample = build_sample_frame()
     payload = bytes.fromhex(sample.frame_hex)
@@ -118,3 +168,90 @@ def test_reader_skips_garbage_until_mbus_start() -> None:
     thread.join(timeout=5.0)
     assert not thread.is_alive(), "reader did not terminate"
     assert len(received) == 1
+
+
+class RaisingSerial:
+    """Serial stub whose ``read`` raises, simulating a port fault."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def read(self, size: int = 1) -> bytes:
+        raise serial.SerialException("simulated serial fault")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_reader_reconnects_after_serial_error() -> None:
+    """A serial fault must reconnect, not kill the thread (and the app)."""
+    sample = build_sample_frame()
+    payload = bytes.fromhex(sample.frame_hex)
+
+    attempts = [0]
+    received: list[MeterData] = []
+
+    def callback(data: MeterData) -> None:
+        received.append(data)
+        reader.stop()
+
+    def factory() -> object:
+        attempts[0] += 1
+        if attempts[0] == 1:
+            return RaisingSerial()
+        return FakeSerial(payload + b"\x00" * 64)
+
+    reader = NoeMeterReader(
+        key_hex=sample.key.hex(),
+        serial_factory=factory,
+        callback=callback,
+    )
+    reader.reconnect_backoff_seconds = 0  # no real sleep in tests
+
+    thread = Thread(target=reader.start)
+    thread.start()
+    thread.join(timeout=5.0)
+    assert not thread.is_alive(), "reader did not terminate"
+    assert attempts[0] == 2, "reader did not reopen the port after the fault"
+    assert len(received) == 1
+
+
+def test_reader_logs_heartbeat_with_diagnostic_when_no_data(caplog) -> None:
+    """When nothing is read, the heartbeat must point at the likely cause."""
+    box: list[NoeMeterReader] = []
+    clock = [0.0]
+
+    def fake_monotonic() -> float:
+        clock[0] += 100.0  # advance past the heartbeat interval each call
+        return clock[0]
+
+    class SilentSerial:
+        def __init__(self) -> None:
+            self.closed = False
+            self._reads = 0
+
+        def read(self, size: int = 1) -> bytes:
+            self._reads += 1
+            if self._reads >= 4:
+                box[0].stop()
+            return b""  # always a timeout, never any data
+
+        def close(self) -> None:
+            self.closed = True
+
+    reader = NoeMeterReader(
+        key_hex="00" * 16,
+        serial_factory=SilentSerial,
+        monotonic=fake_monotonic,
+    )
+    box.append(reader)
+
+    with caplog.at_level(logging.INFO, logger="meter.noe.read"):
+        thread = Thread(target=reader.start)
+        thread.start()
+        thread.join(timeout=5.0)
+
+    assert not thread.is_alive(), "reader did not terminate"
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "reader heartbeat" in messages
+    assert "no bytes received" in messages

--- a/smartmeter/tests/test_smartmeter.py
+++ b/smartmeter/tests/test_smartmeter.py
@@ -52,9 +52,11 @@ def test_setup_passes_got_meter_data_callback() -> None:
     assert callback == meter.got_meter_data
 
 
-def test_setup_connects_reader() -> None:
+def test_setup_does_not_open_serial_port() -> None:
+    # The reader opens the port in start(); setup() must not open it too,
+    # otherwise the device is held by two handles (and logged twice).
     _, build_reader, _ = _make_meter(dict(_BASE_CFG))
-    build_reader.return_value.connect.assert_called_once()
+    build_reader.return_value.connect.assert_not_called()
 
 
 def test_profile_lookup_matches_registry() -> None:


### PR DESCRIPTION
## Hintergrund

Folgeproblem aus #97: nach dem Parity-Fix (#99) startete der EVN/Netz-NÖ-Reader zwar ohne Crash, las aber **keinen einzigen Frame** und das Add-on fuhr sofort wieder herunter (`reader thread exited, shutting down`).

## Root Cause

`NoeMeterReader._read_frame` konnte einen **Serial-Timeout nicht von EOF unterscheiden**: pyserial gibt bei einem Timeout (kein Byte innerhalb `timeout`) `b""` zurück — das passiert ständig zwischen Frames und im Fenster nach dem Connect, bevor der Sagemcom T210-D seinen ersten Frame pusht. Der Reader behandelte das als End-of-Stream, kehrte zurück, der Thread starb und `smartmeter.py` fuhr die ganze App herunter.

Die Unit-Tests fielen nicht auf, weil ihr `FakeSerial` `b""` nur bei leerem Puffer (= echtes EOF im endlichen Test-Stream) liefert.

## Änderungen

- **Timeout-Fix:** leere Reads als Timeout behandeln und weiter warten.
- **Überwachter Reconnect-Loop in `start()`:** Serial-Fehler und ein Schwall Frame-Fehler führen jetzt zu einem Reconnect nach Backoff statt den Thread (und das Add-on) zu beenden. Das nie aufgerufene `recover()` (toter Code) ist entfernt.
- **Doppeltes `connect()` behoben:** `setup()` öffnete den Port und `start()` nochmal → zwei Handles auf dasselbe Gerät (= die doppelte Log-Zeile im Issue). Jetzt öffnet nur noch `start()`.
- **Diagnose-Logging:** 30s-Heartbeat (`bytes/syncs/frames/decoded/failures`) plus ein WARN-Hinweis, der die Zähler auf eine wahrscheinliche Ursache mappt:
  - keine Bytes → Verkabelung / Port / Baudrate / Parity
  - Bytes, aber kein Sync → Framing / Zählertyp
  - Frames, aber kein Decode → Entschlüsselungs-Key

  Raw-Frame-Hex wird zusätzlich auf DEBUG geloggt.

## Tests

- `test_reader_survives_serial_timeouts_before_first_frame` (Regression #97, 2. Report)
- `test_reader_reconnects_after_serial_error`
- `test_reader_logs_heartbeat_with_diagnostic_when_no_data`
- `test_setup_connects_reader` → `test_setup_does_not_open_serial_port` (neuer Vertrag)

`84 passed`, ruff sauber. CHANGELOG/Version-Bump folgt beim Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)