### PR TITLE
feat(standalone): supervisor-free Docker image for standalone operation (#101)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,3 +79,27 @@ jobs:
             BUILD_FROM=ghcr.io/hassio-addons/base-python:stable
           push: "false"
           cosign: "false"
+
+  test-build-standalone:
+    name: "Test build standalone multi-arch image"
+    needs: pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
+
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v3
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Test build standalone image"
+        uses: docker/build-push-action@v6
+        with:
+          context: smartmeter
+          file: smartmeter/Dockerfile.standalone
+          platforms: linux/amd64,linux/arm64
+          push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,39 @@ jobs:
             BUILD_FROM=ghcr.io/hassio-addons/base-python:stable
           push: "true"
           cosign: "false"
+
+  build-standalone:
+    name: "Build and publish standalone multi-arch image"
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
+        with:
+          ref: main
+
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v3
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Log in to Docker Hub"
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Build and push standalone image"
+        uses: docker/build-push-action@v6
+        with:
+          context: smartmeter
+          file: smartmeter/Dockerfile.standalone
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:${{ github.event.release.tag_name }}
+            docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest

--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ cp smartmeter-config.example.yaml smartmeter-config.yaml
 # Edit smartmeter-config.yaml: set mqtt.host, dlms.key, dlms.port, …
 ```
 
-1. Start with docker compose (using the provided `smartmeter/docker-compose.standalone.yml`):
+1. Start with docker compose (from inside `smartmeter/`, using the provided `docker-compose.standalone.yml`):
 
 ```bash
-docker compose -f smartmeter/docker-compose.standalone.yml up -d
+docker compose -f docker-compose.standalone.yml up -d
 ```
 
-Or run directly with `docker run`:
+Or run directly with `docker run` (also from inside `smartmeter/`):
 
 ```bash
 docker run -d --restart unless-stopped \
   --device /dev/ttyUSB0:/dev/ttyUSB0 \
-  -v "$(pwd)/smartmeter/smartmeter-config.yaml:/config/smartmeter-config.yaml:ro" \
+  -v "$(pwd)/smartmeter-config.yaml:/config/smartmeter-config.yaml:ro" \
   docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,47 @@ To use this program on the homeassistant raspberry pi as addon follow this steps
     As hostname use the homeassistant address. As username / password use a normal home assistant user or configure credentials in the Mosquitto broker.
 13. start the addon
 
-### Standalone
+### Standalone (Docker)
+
+The add-on image requires the Home Assistant Supervisor and cannot run on a
+plain Docker host. A separate standalone image is provided for exactly this use
+case ([#101](https://github.com/r00tat/smartmeter_homeassistant_burgenland/issues/101)).
+It is published as a multi-arch image (amd64/arm64):
+
+```text
+docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone
+```
+
+**Steps:**
+
+1. Request the [activation of the customer interface](https://www.netzburgenland.at/kundenservice/smart-metering/smart-metering/kundenschnittstelle.html) and select IR as transport.
+1. Connect the IR reader to the smart meter and to your host machine.
+1. Copy and edit the example config:
+
+```bash
+cd smartmeter/
+cp smartmeter-config.example.yaml smartmeter-config.yaml
+# Edit smartmeter-config.yaml: set mqtt.host, dlms.key, dlms.port, …
+```
+
+1. Start with docker compose (using the provided `smartmeter/docker-compose.standalone.yml`):
+
+```bash
+docker compose -f smartmeter/docker-compose.standalone.yml up -d
+```
+
+Or run directly with `docker run`:
+
+```bash
+docker run -d --restart unless-stopped \
+  --device /dev/ttyUSB0:/dev/ttyUSB0 \
+  -v "$(pwd)/smartmeter/smartmeter-config.yaml:/config/smartmeter-config.yaml:ro" \
+  docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest
+```
+
+Adjust `/dev/ttyUSB0` if your IR reader appears on a different device node.
+
+### Standalone (systemd / uv)
 
 To use this program on an external raspberry pi follow this steps:
 

--- a/docs/superpowers/specs/2026-06-05-standalone-docker-support-design.md
+++ b/docs/superpowers/specs/2026-06-05-standalone-docker-support-design.md
@@ -1,0 +1,113 @@
+# Standalone Docker Support — Design
+
+**Date:** 2026-06-05
+**Status:** Approved
+**Related:** GitHub issue [#101](https://github.com/r00tat/smartmeter_homeassistant_burgenland/issues/101)
+
+## Problem
+
+Running the project standalone (via `docker-compose`, without the Home Assistant
+Supervisor) broke after commit `216f946`, which switched the container base image
+to `ghcr.io/hassio-addons/base-python:stable`. That base ships **s6-overlay** plus
+the HA add-on init services (`base-addon-banner`, `base-addon-log-level`, …), which
+run **before** the `CMD` and unconditionally contact the Supervisor API:
+
+```
+curl: (6) Could not resolve host: supervisor
+[..] FATAL: Unknown log_level:
+s6-rc: warning: unable to start service base-addon-log-level: command exited 1
+/run/s6/basedir/scripts/rc.init: fatal: stopping the container.
+```
+
+Standalone there is no `supervisor` host, so the init aborts and the container
+stops. A secondary blocker: `run.sh` uses `#!/usr/bin/env bashio` and reads
+`/data/options.json` (Supervisor-generated), neither of which exist standalone.
+
+Key finding: the Python application itself (`python3 -m meter -c <file>`) has **no**
+Supervisor dependency — it just loads a YAML/JSON config file. The entire breakage
+lives in the container layer.
+
+## Chosen Approach
+
+**Approach A — separate standalone artifact** (selected over single-image
+auto-detection variants). The HA add-on path (`Dockerfile`, `run.sh`, hassio base,
+s6/bashio) stays **untouched**. A separate, Supervisor-free image is added for the
+Docker/Compose use case, plus a multi-arch CI release.
+
+## Files
+
+### New
+
+- **`smartmeter/Dockerfile.standalone`**
+  - Base `python:3.13-slim` (glibc, official multi-arch amd64/arm64). No s6, no bashio.
+  - Build context stays `smartmeter/` (same as the add-on `Dockerfile`).
+  - Steps: `COPY requirements.txt` → `pip install --no-cache-dir -r requirements.txt`
+    → `COPY meter ./meter/` → **`COPY config.yaml ./`** (required: `meter/mqtt/device.py`
+    calls `get_sw_version()` which reads `config.yaml`) → `COPY standalone-entrypoint.sh ./`.
+  - `ENTRYPOINT ["/app/standalone-entrypoint.sh"]`.
+  - lxml/pycryptodomex resolve to manylinux wheels on slim → no compiler toolchain needed.
+
+- **`smartmeter/standalone-entrypoint.sh`**
+  - Plain `sh`/`bash`, no bashio.
+  - Resolves config path from env `SMARTMETER_CONFIG`, default `/config/smartmeter-config.yaml`.
+  - If the file is missing/empty → exit non-zero with a clear, human-readable message
+    (not a Python traceback).
+  - `cd /app` then `exec python3 -m meter -c "$CONFIG"` (`exec` so SIGTERM/SIGINT reach
+    the app, which already installs signal handlers in `meter/__main__.py`).
+
+- **`smartmeter/docker-compose.standalone.yml`**
+  - Uses the published image
+    `docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest`.
+  - Maps `/dev/ttyUSB0` device, mounts user config to `/config/smartmeter-config.yaml`,
+    `restart: unless-stopped`.
+  - Includes a commented-out `build:` block (`context: .`, `dockerfile: Dockerfile.standalone`)
+    for building locally instead of pulling.
+
+### Modified
+
+- **`smartmeter/DOCS.md`** — new section "Standalone (Docker / docker-compose)":
+  image name, the `SMARTMETER_CONFIG` convention + default path, and the compose example.
+- **`.github/workflows/release.yml`** — new job `build-standalone` (see CI below).
+- **`.github/workflows/pull_request.yml`** — new job `test-build-standalone` (build only, no push).
+
+### Unchanged (explicitly)
+
+- Add-on `Dockerfile`, `run.sh`, `build.yaml`, `config.yaml` schema/options.
+- `smartmeter-config.example.yaml` stays as the standalone config template, referenced from docs.
+
+## Config Convention
+
+- Env var `SMARTMETER_CONFIG`, default `/config/smartmeter-config.yaml`.
+- The user mounts their YAML there. Format is identical to the existing
+  `smartmeter-config.example.yaml` — plain YAML, no `/data/options.json`, no JSON requirement.
+
+## CI / Release (multi-arch)
+
+- **`release.yml` → `build-standalone`** (runs alongside the existing `build` job):
+  - `docker/setup-qemu-action` + `docker/setup-buildx-action` + `docker/login-action`
+    (`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets, already present).
+  - `docker/build-push-action` with `context: smartmeter`,
+    `file: smartmeter/Dockerfile.standalone`, `platforms: linux/amd64,linux/arm64`.
+  - Pushes a **single multi-arch manifest** to
+    `docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone`
+    with tags `<release-tag>` and `latest`.
+- **`pull_request.yml` → `test-build-standalone`**:
+  - Same buildx setup, `platforms: linux/amd64,linux/arm64`, `push: false` — build check only.
+
+## Error Handling
+
+- Entrypoint: missing/empty config → clear message + non-zero exit.
+- Application: unchanged (existing `try/except` and signal handling in `meter/__main__.py`).
+
+## Testing / Verification
+
+- CI `test-build-standalone` verifies both arch images build.
+- Manual: `docker compose -f docker-compose.standalone.yml up` with the example config
+  and a serial device → container starts, no Supervisor contact, app loads config.
+- Existing pytest/ruff/mypy jobs unaffected.
+
+## Out of Scope (YAGNI)
+
+- No changes to the add-on image / s6 / bashio.
+- No auto-detection entrypoint (single-image approaches B/C rejected).
+- No architectures beyond amd64/arm64 (the add-on publishes only these).

--- a/smartmeter/DOCS.md
+++ b/smartmeter/DOCS.md
@@ -79,6 +79,9 @@ To use a different path inside the container, set the `SMARTMETER_CONFIG`
 environment variable:
 
 ```bash
+# Minimal example — illustrates the env var only. For real use, add the serial
+# device (--device), detach (-d), and a restart policy (--restart), or use the
+# docker-compose.standalone.yml example below.
 docker run -e SMARTMETER_CONFIG=/myconfig.yaml \
   -v /path/to/myconfig.yaml:/myconfig.yaml \
   docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest

--- a/smartmeter/DOCS.md
+++ b/smartmeter/DOCS.md
@@ -89,9 +89,12 @@ docker run -e SMARTMETER_CONFIG=/myconfig.yaml \
 
 ### docker compose (recommended)
 
-Use the provided `docker-compose.standalone.yml` example:
+Use the provided `docker-compose.standalone.yml` example. Run it from inside
+the `smartmeter/` directory (where the compose file and your
+`smartmeter-config.yaml` live):
 
 ```bash
+cd smartmeter
 docker compose -f docker-compose.standalone.yml up -d
 ```
 

--- a/smartmeter/DOCS.md
+++ b/smartmeter/DOCS.md
@@ -52,3 +52,55 @@ while `tls` is `false`):
 
 Certificate paths must be readable from within the add-on container (e.g.
 mounted via `share:ro` or `config:ro`).
+
+## Standalone (Docker / docker-compose)
+
+The standalone image runs **without** the Home Assistant Supervisor, making it
+suitable for any host that can run Docker (a plain Raspberry Pi, a NAS, a VPS,
+etc.). It is published as a multi-arch image (amd64 and arm64) at:
+
+```text
+docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone
+```
+
+### Configuration
+
+The standalone image reads a plain YAML config file — the same format as
+`smartmeter-config.example.yaml`. Mount it into the container at
+`/config/smartmeter-config.yaml`:
+
+```bash
+# One-time setup
+cp smartmeter-config.example.yaml smartmeter-config.yaml
+# Edit smartmeter-config.yaml: set mqtt.host, dlms.key, dlms.port, …
+```
+
+To use a different path inside the container, set the `SMARTMETER_CONFIG`
+environment variable:
+
+```bash
+docker run -e SMARTMETER_CONFIG=/myconfig.yaml \
+  -v /path/to/myconfig.yaml:/myconfig.yaml \
+  docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest
+```
+
+### docker compose (recommended)
+
+Use the provided `docker-compose.standalone.yml` example:
+
+```bash
+docker compose -f docker-compose.standalone.yml up -d
+```
+
+The compose file mounts `./smartmeter-config.yaml` and maps the serial device
+`/dev/ttyUSB0`. Adjust the device path in the file if your IR reader appears on
+a different node (e.g. `/dev/ttyUSB1` or `/dev/ttyAMA0`).
+
+### Minimal docker run
+
+```bash
+docker run -d --restart unless-stopped \
+  --device /dev/ttyUSB0:/dev/ttyUSB0 \
+  -v "$(pwd)/smartmeter-config.yaml:/config/smartmeter-config.yaml:ro" \
+  docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest
+```

--- a/smartmeter/Dockerfile.standalone
+++ b/smartmeter/Dockerfile.standalone
@@ -1,0 +1,16 @@
+ARG BUILD_FROM=python:3.13-slim
+FROM $BUILD_FROM
+
+ENV LANG=C.UTF-8
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY meter ./meter/
+COPY config.yaml ./
+COPY standalone-entrypoint.sh ./
+RUN chmod +x /app/standalone-entrypoint.sh
+
+ENTRYPOINT ["/app/standalone-entrypoint.sh"]

--- a/smartmeter/Dockerfile.standalone
+++ b/smartmeter/Dockerfile.standalone
@@ -10,7 +10,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY meter ./meter/
 COPY config.yaml ./
-COPY standalone-entrypoint.sh ./
-RUN chmod +x /app/standalone-entrypoint.sh
+COPY --chmod=755 standalone-entrypoint.sh ./
 
 ENTRYPOINT ["/app/standalone-entrypoint.sh"]

--- a/smartmeter/docker-compose.standalone.yml
+++ b/smartmeter/docker-compose.standalone.yml
@@ -1,0 +1,29 @@
+# Standalone smartmeter reader — runs WITHOUT the Home Assistant Supervisor.
+#
+# Quick start:
+#   1. Copy the example config:  cp smartmeter-config.example.yaml smartmeter-config.yaml
+#   2. Edit smartmeter-config.yaml (MQTT host, AES key, serial port, …)
+#   3. Start:  docker compose -f docker-compose.standalone.yml up -d
+
+services:
+  smartmeter:
+    image: docker.io/paulwoelfel/smartmeter_homeassistant_burgenland_standalone:latest
+
+    # Uncomment the block below (and comment out the image: line above) to build
+    # locally from the repo instead of pulling the published image.
+    # Run docker compose from inside the smartmeter/ directory in that case.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.standalone
+
+    restart: unless-stopped
+
+    volumes:
+      # Mount your edited config file (read-only).
+      - ./smartmeter-config.yaml:/config/smartmeter-config.yaml:ro
+
+    devices:
+      # Adjust the host path if your IR reader appears on a different device node
+      # (e.g. /dev/ttyUSB1, /dev/ttyAMA0, …).
+      - /dev/ttyUSB0:/dev/ttyUSB0

--- a/smartmeter/standalone-entrypoint.sh
+++ b/smartmeter/standalone-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+CONFIG="${SMARTMETER_CONFIG:-/config/smartmeter-config.yaml}"
+
+if [ ! -f "$CONFIG" ] || [ ! -s "$CONFIG" ]; then
+    echo "ERROR: Config file not found or empty: $CONFIG" >&2
+    echo "" >&2
+    echo "Mount your configuration file and retry, e.g.:" >&2
+    echo "  docker run -v /path/to/your/smartmeter-config.yaml:/config/smartmeter-config.yaml smartmeter-standalone" >&2
+    echo "" >&2
+    echo "Or point to a different path via the SMARTMETER_CONFIG environment variable:" >&2
+    echo "  docker run -e SMARTMETER_CONFIG=/myconfig.yaml -v /path/to/myconfig.yaml:/myconfig.yaml smartmeter-standalone" >&2
+    exit 1
+fi
+
+cd /app
+exec python3 -m meter -c "$CONFIG"


### PR DESCRIPTION
## Summary

Fixes standalone operation (plain `docker` / `docker-compose`, without the Home Assistant Supervisor), which broke after the base image switched to `ghcr.io/hassio-addons/base-python:stable`. That base ships s6-overlay add-on init services (`base-addon-banner`, `base-addon-log-level`, …) that contact the Supervisor API and abort the container when no `supervisor` host exists. See #101.

The Python app itself has **no** Supervisor dependency — it just loads a YAML config. So this adds a separate, supervisor-free image and leaves the HA add-on path completely untouched.

- **`smartmeter/Dockerfile.standalone`** — base `python:3.13-slim`, no s6/bashio. Copies `config.yaml` (needed by `get_sw_version()`), installs deps (manylinux wheels, no toolchain).
- **`smartmeter/standalone-entrypoint.sh`** — plain `sh`, resolves config from `SMARTMETER_CONFIG` (default `/config/smartmeter-config.yaml`), clear error on missing/empty config, then `exec python3 -m meter -c …` (proper signal delivery).
- **`smartmeter/docker-compose.standalone.yml`** — copy-paste example (published image, config mount, device map, `restart: unless-stopped`, optional local `build:` block).
- **`smartmeter/DOCS.md` + `README.md`** — new "Standalone (Docker)" usage sections.
- **CI** — new `build-standalone` (release: multi-arch amd64/arm64 manifest → `paulwoelfel/smartmeter_homeassistant_burgenland_standalone`, tags version + `latest`) and `test-build-standalone` (PR: build-only). Existing add-on jobs unchanged.

Design spec: `docs/superpowers/specs/2026-06-05-standalone-docker-support-design.md`.

## Test Plan

- [x] `pytest` (80 passed) — no Python code changed
- [x] `docker build -f smartmeter/Dockerfile.standalone smartmeter` builds; entrypoint errors clearly on missing config; loads config on happy path
- [x] `docker compose -f smartmeter/docker-compose.standalone.yml config` validates
- [ ] CI `test-build-standalone` builds both arches on this PR
- [ ] On release, `build-standalone` publishes the multi-arch image