### PR TITLE
Dependabot: gurux-dlms Updates ignorieren

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     ignore:
       # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
       - dependency-name: 'homeassistant'
+      # gurux-dlms frequently breaks its API even in patch releases, so updates are ignored
+      - dependency-name: 'gurux-dlms'
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## Was

Dependabot ignoriert ab jetzt Updates für `gurux-dlms` im pip-Ecosystem.

## Warum

`gurux-dlms` ändert immer wieder seine API – teilweise sogar bei Patch-Releases. Dadurch verursachen automatische Dependabot-Updates wiederholt Probleme. Daher werden Updates für dieses Paket nicht mehr vorgeschlagen.

## Änderung

In `.github/dependabot.yml` wurde `gurux-dlms` zur `ignore`-Liste des pip-Ecosystems hinzugefügt (analog zu `homeassistant`).

https://claude.ai/code/session_0185JDG8F4HbKWgEt6cSjuUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0185JDG8F4HbKWgEt6cSjuUZ)_